### PR TITLE
Update to 4.39.0.9

### DIFF
--- a/Xamarin.RevenueCat.iOS.Extensions/Xamarin.RevenueCat.iOS.Extensions.csproj
+++ b/Xamarin.RevenueCat.iOS.Extensions/Xamarin.RevenueCat.iOS.Extensions.csproj
@@ -4,7 +4,7 @@
         <IsPackable>true</IsPackable>
         <PackageId>Xamarin.RevenueCat.iOS.Extensions</PackageId>
         <Description>Contains convenience methods and async extensions for Xamarin.RevenueCat.iOS</Description>
-        <Version>4.39.0.8</Version>
+        <Version>4.39.0.9</Version>
         <Authors>Christian Kapplmüller, Albilaga Linggra Pradana</Authors>
         <Company>fun.music IT GmbH</Company>
         <PackageOutputPath>nugetoutput</PackageOutputPath>

--- a/Xamarin.RevenueCat.iOS/Xamarin.RevenueCat.iOS.csproj
+++ b/Xamarin.RevenueCat.iOS/Xamarin.RevenueCat.iOS.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <IsPackable>true</IsPackable>
         <PackageId>Xamarin.RevenueCat.iOS</PackageId>
-        <Version>4.39.0.8</Version>
+        <Version>4.39.0.9</Version>
         <Description>Contains bindings for https://docs.revenuecat.com/docs/ios</Description>
         <Authors>Christian Kapplmüller, Albilaga Linggra Pradana</Authors>
         <Company>fun.music IT GmbH</Company>

--- a/Xamarin.RevenueCatUI.iOS.Extensions/Paywall.cs
+++ b/Xamarin.RevenueCatUI.iOS.Extensions/Paywall.cs
@@ -52,8 +52,12 @@ namespace Xamarin.RevenueCatUI.iOS.Extensions
                 _callback = callback ?? throw new ArgumentNullException(nameof(callback));
             }
 
-            public override void PaywallViewControllerDidFinishRestoringWithCustomerInfo(
-                RCPaywallViewController controller, RCCustomerInfo customerInfo)
+            public override void DidFinishRestoring(RCPaywallViewController controller, RCCustomerInfo customerInfo)
+            {
+                _callback?.Invoke(customerInfo);
+            }
+
+            public override void DidFinishPurchasing(RCPaywallViewController controller, RCCustomerInfo customerInfo)
             {
                 _callback?.Invoke(customerInfo);
             }

--- a/Xamarin.RevenueCatUI.iOS.Extensions/Paywall.cs
+++ b/Xamarin.RevenueCatUI.iOS.Extensions/Paywall.cs
@@ -9,7 +9,7 @@ namespace Xamarin.RevenueCatUI.iOS.Extensions
     public static class Paywall
     {
         public static Task<RCCustomerInfo> PresentPaywallAsync(this UIViewController topVc, RCOffering offering,
-            CancellationToken cancellationToken = default)
+            bool animate = false, CancellationToken cancellationToken = default)
         {
             var tcs = new TaskCompletionSource<RCCustomerInfo>();
             cancellationToken.Register(() => tcs.TrySetCanceled());
@@ -21,12 +21,12 @@ namespace Xamarin.RevenueCatUI.iOS.Extensions
 
             controller.Delegate = paywallDelegate;
 
-            topVc.InvokeOnMainThread(() => { topVc.PresentViewController(controller, true, null); });
+            topVc.InvokeOnMainThread(() => { topVc.PresentViewController(controller, animate, null); });
             return tcs.Task;
         }
 
         public static Task<RCCustomerInfo> PushPaywallAsync(this UINavigationController navigationController,
-            RCOffering offering, CancellationToken cancellationToken = default)
+            RCOffering offering, bool animate = false, CancellationToken cancellationToken = default)
         {
             var tcs = new TaskCompletionSource<RCCustomerInfo>();
             cancellationToken.Register(() => tcs.TrySetCanceled());
@@ -39,7 +39,7 @@ namespace Xamarin.RevenueCatUI.iOS.Extensions
             controller.Delegate = paywallDelegate;
 
             navigationController.InvokeOnMainThread(
-                () => { navigationController.PushViewController(controller, true); });
+                () => { navigationController.PushViewController(controller, animate); });
             return tcs.Task;
         }
 

--- a/Xamarin.RevenueCatUI.iOS.Extensions/Xamarin.RevenueCatUI.iOS.Extensions.csproj
+++ b/Xamarin.RevenueCatUI.iOS.Extensions/Xamarin.RevenueCatUI.iOS.Extensions.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <IsPackable>true</IsPackable>
         <PackageId>Xamarin.RevenueCatUI.iOS.Extensions</PackageId>
-        <Version>4.39.0.8</Version>
+        <Version>4.39.0.9</Version>
         <Description>Contains bindings for https://docs.revenuecat.com/docs/ios</Description>
         <Authors>Christian Kapplmüller, Albilaga Linggra Pradana</Authors>
         <Company>fun.music IT GmbH</Company>

--- a/Xamarin.RevenueCatUI.iOS/ApiDefinitions.cs
+++ b/Xamarin.RevenueCatUI.iOS/ApiDefinitions.cs
@@ -79,48 +79,48 @@ namespace Xamarin.RevenueCatUI.iOS
     {
         // @optional -(void)paywallViewControllerDidStartPurchase:(RCPaywallViewController * _Nonnull)controller;
         [Export("paywallViewControllerDidStartPurchase:")]
-        void PaywallViewControllerDidStartPurchase(RCPaywallViewController controller);
+        void DidStartPurchase(RCPaywallViewController controller);
 
         // @optional -(void)paywallViewController:(RCPaywallViewController * _Nonnull)controller didStartPurchaseWithPackage:(RCPackage * _Nonnull)package;
         [Export("paywallViewController:didStartPurchaseWithPackage:")]
-        void PaywallViewController(RCPaywallViewController controller, RCPackage package);
+        void DidStartPurchase(RCPaywallViewController controller, RCPackage package);
 
         // @optional -(void)paywallViewController:(RCPaywallViewController * _Nonnull)controller didFinishPurchasingWithCustomerInfo:(RCCustomerInfo * _Nonnull)customerInfo;
         [Export("paywallViewController:didFinishPurchasingWithCustomerInfo:")]
-        void PaywallViewController(RCPaywallViewController controller, RCCustomerInfo customerInfo);
+        void DidFinishPurchasing(RCPaywallViewController controller, RCCustomerInfo customerInfo);
 
         // @optional -(void)paywallViewController:(RCPaywallViewController * _Nonnull)controller didFinishPurchasingWithCustomerInfo:(RCCustomerInfo * _Nonnull)customerInfo transaction:(RCStoreTransaction * _Nullable)transaction;
         [Export("paywallViewController:didFinishPurchasingWithCustomerInfo:transaction:")]
-        void PaywallViewController(RCPaywallViewController controller, RCCustomerInfo customerInfo,
+        void DidFinishPurchasing(RCPaywallViewController controller, RCCustomerInfo customerInfo,
             [NullAllowed] RCStoreTransaction transaction);
 
         // @optional -(void)paywallViewControllerDidCancelPurchase:(RCPaywallViewController * _Nonnull)controller;
         [Export("paywallViewControllerDidCancelPurchase:")]
-        void PaywallViewControllerDidCancelPurchase(RCPaywallViewController controller);
+        void DidCancelPurchase(RCPaywallViewController controller);
 
         // @optional -(void)paywallViewController:(RCPaywallViewController * _Nonnull)controller didFailPurchasingWithError:(NSError * _Nonnull)error;
         [Export("paywallViewController:didFailPurchasingWithError:")]
-        void PaywallViewController(RCPaywallViewController controller, NSError error);
+        void DidFailPurchasing(RCPaywallViewController controller, NSError error);
 
         // @optional -(void)paywallViewControllerDidStartRestore:(RCPaywallViewController * _Nonnull)controller;
         [Export("paywallViewControllerDidStartRestore:")]
-        void PaywallViewControllerDidStartRestore(RCPaywallViewController controller);
+        void DidStartRestore(RCPaywallViewController controller);
 
         // @optional -(void)paywallViewController:(RCPaywallViewController * _Nonnull)controller didFinishRestoringWithCustomerInfo:(RCCustomerInfo * _Nonnull)customerInfo;
         [Export("paywallViewController:didFinishRestoringWithCustomerInfo:")]
-        void PaywallViewControllerDidFinishRestoringWithCustomerInfo(RCPaywallViewController controller,
+        void DidFinishRestoring(RCPaywallViewController controller,
             RCCustomerInfo customerInfo);
 
         // @optional -(void)paywallViewController:(RCPaywallViewController * _Nonnull)controller didFailRestoringWithError:(NSError * _Nonnull)error;
         [Export("paywallViewController:didFailRestoringWithError:")]
-        void PaywallViewControllerDidFailRestoringWithError(RCPaywallViewController controller, NSError error);
+        void DidFailRestoring(RCPaywallViewController controller, NSError error);
 
         // @optional -(void)paywallViewControllerWasDismissed:(RCPaywallViewController * _Nonnull)controller;
         [Export("paywallViewControllerWasDismissed:")]
-        void PaywallViewControllerWasDismissed(RCPaywallViewController controller);
+        void WasDismissed(RCPaywallViewController controller);
 
         // @optional -(void)paywallViewController:(RCPaywallViewController * _Nonnull)controller didChangeSizeTo:(CGSize)size;
         [Export("paywallViewController:didChangeSizeTo:")]
-        void PaywallViewController(RCPaywallViewController controller, CGSize size);
+        void DidChangeSizeTo(RCPaywallViewController controller, CGSize size);
     }
 }

--- a/Xamarin.RevenueCatUI.iOS/Xamarin.RevenueCatUI.iOS.csproj
+++ b/Xamarin.RevenueCatUI.iOS/Xamarin.RevenueCatUI.iOS.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <IsPackable>true</IsPackable>
         <PackageId>Xamarin.RevenueCatUI.iOS</PackageId>
-        <Version>4.39.0.8</Version>
+        <Version>4.39.0.9</Version>
         <Description>Contains bindings for https://docs.revenuecat.com/docs/ios</Description>
         <Authors>Christian Kapplmüller, Albilaga Linggra Pradana</Authors>
         <Company>fun.music IT GmbH</Company>

--- a/Xamarin.RevenueCatUI.iOS/ios/project.pbxproj
+++ b/Xamarin.RevenueCatUI.iOS/ios/project.pbxproj
@@ -1,0 +1,2403 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 56;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		006EE37E0CF6554326995C0A26EC2200 /* PurchaseButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F7F005517F4D15A4B80E917238D97D0 /* PurchaseButton.swift */; };
+		00E572A6D617F3989DE3D3B963322D42 /* PaywallEventSerializer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47FDB7A0628B5B9951743BBF97ABCC7A /* PaywallEventSerializer.swift */; };
+		018B59A32810D9C4924317B3A3F26C24 /* background.jpg in Resources */ = {isa = PBXBuildFile; fileRef = 6F4969D08ABA73D221FE57019A14CDE6 /* background.jpg */; };
+		01E923CA33BC99A7959FEBD1FCA1A1F8 /* ViewExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36B9946F0EB0253FF8CB6EDCBA3253A6 /* ViewExtensions.swift */; };
+		02DBDC623AFCDE37C027DD9A6B2D0958 /* TestData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FE59D06B676356311DEBC9409E7BDEE /* TestData.swift */; };
+		04144875667A95B3B2F613A3B2B61B67 /* GetProductEntitlementMappingOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1015E76DED97C427C4AC84304ABD8B99 /* GetProductEntitlementMappingOperation.swift */; };
+		04E071224DD5C8E19130ADCB3C6C62DE /* ProcessedLocalizedConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = BED43C5AAB71F3545DFBDD88EAA849EB /* ProcessedLocalizedConfiguration.swift */; };
+		053D6E85E904884D0DA65143D14CDB18 /* Locale+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DCF45CE4D6986498F68051BF600585B /* Locale+Extensions.swift */; };
+		0606A8EE3BD6209C1B33D74D7B2789BA /* PaywallView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D608699E7764EC351B37B87E66504D16 /* PaywallView.swift */; };
+		07013255BD7E6ABED38C997458BA0AAC /* Localization.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6702401664EC1391F906C9451C19B780 /* Localization.swift */; };
+		073E4BF5193061F2CE03961ABC3A0B6E /* SwiftUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7FDC3504D3D207532A27EEE4C25D13D3 /* SwiftUI.framework */; };
+		09CFAF601B451B7CB522FE63004D0916 /* SandboxEnvironmentDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A267014AAE8F350958902647265514C /* SandboxEnvironmentDetector.swift */; };
+		0A08E87B838147DB297B48D3D4A0150D /* CustomerInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6F87F25863D57D386A7A864CFCAB20B /* CustomerInfo.swift */; };
+		0B413672C74F4D24022AC6E4A7E81021 /* Template5View.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8786DE2D3899CA84A23124293133F29D /* Template5View.swift */; };
+		0BB874C866E0C415606AED5E816DAED9 /* TemplateViewConfiguration+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7AEDD299A97325A391D005AD569CCC55 /* TemplateViewConfiguration+Extensions.swift */; };
+		0C415C709D84CE7F07CA4AFFE137CA26 /* Purchases+async.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12B490CCDAAAC6E5C8FD853D3A7B1049 /* Purchases+async.swift */; };
+		0C6AE8640A3BD0281FCC077268B3A374 /* ArraySlice_UInt8+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE359CCD53E08DB5B8A42BA69C05EBD1 /* ArraySlice_UInt8+Extensions.swift */; };
+		0DEBB2D5999016932F860FAF8279E419 /* DebugViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E54795119F90AFB6D67DCC19F3D83B4 /* DebugViewModel.swift */; };
+		0EE73F9B77896B677BB68602B9219A35 /* PostAdServicesTokenOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = A96E181F1B6B0C902B41B9965F33F48E /* PostAdServicesTokenOperation.swift */; };
+		0F3C1D770691D7479D3AB5D5E54B34A8 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 45B01B021164958A1A1625CE10CD6777 /* Foundation.framework */; };
+		1032461A61B2DAFB7C2208550347693C /* StoreKit2Setting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5184776B9AC1C9A7DA509C2297014A09 /* StoreKit2Setting.swift */; };
+		104F13F47E810E97D6C99D76B244A268 /* Optional+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E3B60AAB45031386B36873ADBF71D52 /* Optional+Extensions.swift */; };
+		112F3645B291AC1833148B90AE43CC07 /* PaywallViewMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = F78AE86FCC6762CCEB9674F05ACF5B7D /* PaywallViewMode.swift */; };
+		116BD659AAB7440FBD20DB47CA7CC834 /* IconView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B32EE4C995105DFF7767F02E1C72823F /* IconView.swift */; };
+		118FE39619AC26C5E463E0929931074F /* ProductEntitlementMappingCallback.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2308FBF7951C8C0A9766F5B0041B96CD /* ProductEntitlementMappingCallback.swift */; };
+		12DED8673096618D59E9DC856D3DFAA9 /* SystemInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65F8FB72680A164D17E715E2D9BA11A7 /* SystemInfo.swift */; };
+		1377312B26865BDDF4A90B82625628B6 /* Template3View.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25CBF776E957DAA2944AC2FE58157502 /* Template3View.swift */; };
+		13A6B1C3230B15B2FA89F29693F037DC /* StoreKitRequestFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFB920147612D6EA7D0D6FD94A75B86E /* StoreKitRequestFetcher.swift */; };
+		13D40C311B7930FFA9C6C8EC7DE06A12 /* Assertions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30DF6F969560A7C4881C71B84720218F /* Assertions.swift */; };
+		14E02ED940865DACA96385D44C1F7D24 /* LoadingPaywallView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A508095BB33CBE0C05207224E994391B /* LoadingPaywallView.swift */; };
+		15CACBF78DD8C67209CD6807D6B78D99 /* CustomerInfoManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = DECE704283A407E168DCF9F043E27ACE /* CustomerInfoManager.swift */; };
+		16B65D18F9B2406E356FA277B18F4DAF /* NonEmptyStringDecodable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D5274C800BC3283A9BCF045ABAB89E9 /* NonEmptyStringDecodable.swift */; };
+		1741D22BEB57DC4D8C2CD77F2BD3A130 /* TrialOrIntroEligibilityChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42470306638B63A79F5841EE989E46F9 /* TrialOrIntroEligibilityChecker.swift */; };
+		182A9F33025EE9704B82C1DB3EA84800 /* ImageLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8226A5D9E5747AA532C84FB572704B3 /* ImageLoader.swift */; };
+		19008C27D96D2C7A0CD2FE6786D5C963 /* CustomerInfoResponseHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D9EF3D22D8759B4F58CD80511161030 /* CustomerInfoResponseHandler.swift */; };
+		19863FC61B0919DCE1C6D9999A617FAE /* InMemoryCachedObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C07E7D145AD32E7B349F50196E9D472 /* InMemoryCachedObject.swift */; };
+		19D6A522CBE323D568DAF2F83D27D7E0 /* Box.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6033FA7AF38C1F87F0BB91E10EEACBD2 /* Box.swift */; };
+		1B0495ED6566F0D461759E3490AA9603 /* PurchasesError.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0F76AC9DA6F7A91784197B8F038A738 /* PurchasesError.swift */; };
+		1C1DD057CD0EA1FB136207A517225B0B /* Store+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 989F308620052EE1D83F48AEAD7B0139 /* Store+Extensions.swift */; };
+		1D4E5C0F1661DCB092313A2B31790A9D /* TemplateViewConfiguration+Images.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC3263E242A6B3C66808B6735D5C606F /* TemplateViewConfiguration+Images.swift */; };
+		1EC21BDA4349713704A92470F9169AC5 /* PurchasedSK2Product.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1D03A4D74963BEC22962AA075B632F3 /* PurchasedSK2Product.swift */; };
+		1F03D0F6EA0859EB7F55F66BF42392DF /* StoreKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A2ADFA53C6DA7111B4E15FC295182AF /* StoreKit.framework */; };
+		1F28D73B409819940831595BC4A3AB10 /* ProductsFetcherSK1.swift in Sources */ = {isa = PBXBuildFile; fileRef = A138B8781D9D42E24FBF354557201650 /* ProductsFetcherSK1.swift */; };
+		205DADC9E71042BEC1DC0CE25336C688 /* DebugViewSheetPresentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D7021A1B5D6CC4892057D59033AEB68 /* DebugViewSheetPresentation.swift */; };
+		209926FDFF32EEFA5F9BDF53D2E66C5E /* IntroEligibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = D404C4770BBF4D9D2E995B6121EBC98C /* IntroEligibility.swift */; };
+		21C107DEA22C3B6CD3DF357633ADBBC4 /* HTTPResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 053471365AC83C6665EC2185F7C5DB6D /* HTTPResponse.swift */; };
+		22A6A0C05BF1E8A2FA0EBFD96FB56CCF /* GetOfferingsOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9F5171509593BA208283A9E48B49AC5 /* GetOfferingsOperation.swift */; };
+		22A79868B1DF8EE86783A4397D4D52A1 /* TestStoreProductDiscount.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58F7BCD9188AFAED6E5B54753313FFAF /* TestStoreProductDiscount.swift */; };
+		22DDC88357A9DF2EBFF82655BAF0E881 /* Logger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 117C91FD3ABC917953962A303F46588A /* Logger.swift */; };
+		2306098E446C8A93ED5279426A2B899B /* ProgressView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37A59D4BA7C39F3C2CFB7178B3FC4CE7 /* ProgressView.swift */; };
+		24C4CF50B0EE9F62C2EF129434E54D50 /* OfflineEntitlementsAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBE6DCD8F6BA05E23B12495A97ED3992 /* OfflineEntitlementsAPI.swift */; };
+		24C647F0B118A6A18B117CB4EC1970C1 /* Attribution.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6A274A2B1498303B33B3868C8C1AC4F /* Attribution.swift */; };
+		25B432F498945E24E0601147757910B4 /* PurchasesType.swift in Sources */ = {isa = PBXBuildFile; fileRef = B09AEDC6DEFB78261D36A242BA09B983 /* PurchasesType.swift */; };
+		265CA78CFD6FD24DE9007BB1B85ED501 /* CustomerAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73C4084C22CDEC98C11010C872AFC826 /* CustomerAPI.swift */; };
+		2693A3581F06FC206C0639FEB081E45C /* Package.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7C2C119FFFD373528222FEDBE119D52 /* Package.swift */; };
+		269C44FB66B5CA753BCB07BA7ADA9C8B /* CachingTrialOrIntroPriceEligibilityChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA8572878BBBEBE1F8479BEDF923B1BA /* CachingTrialOrIntroPriceEligibilityChecker.swift */; };
+		26F4443465CE0C5D21F099B9049B66E7 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 45B01B021164958A1A1625CE10CD6777 /* Foundation.framework */; };
+		294601A026AD1BA464F60A9619F3F273 /* ReceiptStrings.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA923E42D6ED50B7657E73F45A527E08 /* ReceiptStrings.swift */; };
+		296DA5302EB9AD678CD4C81C827891E6 /* PaywallsStrings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CCCBD19E9BD2D38AD333A3AD5328EC4 /* PaywallsStrings.swift */; };
+		2A9AB90992D6BB3D2D467ADC14162AEE /* InAppPurchaseBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1A5AC088187B1A3E4E2CF89C5B277CB /* InAppPurchaseBuilder.swift */; };
+		2AE4A1515175406EB8CBBADA75D129D5 /* DebugView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F4775BD35B655C01C21D38D0C99A400 /* DebugView.swift */; };
+		2D48D7BAC5363DF7F63E5C37BE7BAF13 /* TemplateBackgroundImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9CA5C4542686A4B6E99FEE0E21F3A25 /* TemplateBackgroundImageView.swift */; };
+		2E8CC659ED3BAF17BE0FF36880D58EA8 /* PromotionalOffer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A06C922790FDFE1B4BD74209DB5E11B /* PromotionalOffer.swift */; };
+		2FD65085A50E9B42808346E38A02D6C5 /* UIApplication+RCExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE8EAFC5963CEF92448114B8CF032CBF /* UIApplication+RCExtensions.swift */; };
+		3037B3D95151E50C7B3621F22A05C58D /* ReceiptFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 178AA9CFB3106D2B67393570C1724C6B /* ReceiptFetcher.swift */; };
+		3058048818BE7A990F0B7F8BFACCA0DD /* LocalizedAlertError.swift in Sources */ = {isa = PBXBuildFile; fileRef = A219A4AF3D0D0F76EE4A2C80F5A6E5EA /* LocalizedAlertError.swift */; };
+		30DF69679BB1956D1D0C5F09C82F0910 /* String+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D12C677933E69762F563CAF9D81A475 /* String+Extensions.swift */; };
+		31D028CDC483C3C36DA148358F579C62 /* SK2StoreProduct.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CE96248BEF99DDC1E7850CB57FDDEB0 /* SK2StoreProduct.swift */; };
+		3206A0B530C8962F096DDFD1628FD504 /* PaywallEventsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD3A3592FC72EC9F7F58EAEAFD7C03DB /* PaywallEventsManager.swift */; };
+		32CB4856686E2E838F48D10843ABDFAA /* MacDevice.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D1AA55328DB1CCC616D5AEFB964B5CF /* MacDevice.swift */; };
+		32F054AE47164436F18B78A42CC7BB62 /* ProductsRequestFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A68A4CC5B85F96D96A4C6DF4876CB17 /* ProductsRequestFactory.swift */; };
+		344BFFE3FF3DD29681B6FDC4B70C77D2 /* AnyDecodable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7FFBCBA2C4A5A56499AAEE7841262133 /* AnyDecodable.swift */; };
+		3468D0C0FB59AA9E10D85093D1291188 /* NonSubscriptionTransaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0D03186241780644F5974DB27D4DDA8 /* NonSubscriptionTransaction.swift */; };
+		36E81F2B880F2B6890C350ECA1B27180 /* VerificationResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13F73941C6E2F9A432BDD964F8D635E5 /* VerificationResult.swift */; };
+		3A797C8DC735B78B1842C2CFEE429122 /* DispatchTimeInterval+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB48A0D50ECB8E8D1644A7F8ABCE01B8 /* DispatchTimeInterval+Extensions.swift */; };
+		3AB8D3ECC8DB66D8BFD3C04426520624 /* PurchasedProductsFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8E73EB3897D5A452488D372720E174B /* PurchasedProductsFetcher.swift */; };
+		3AFB81D91D1E5653792F84A9A2633C4D /* SK2Storefront.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1EE9CBD6F97E39B55366105608A72B9B /* SK2Storefront.swift */; };
+		3B1ACDB4E76CAAF8881CC510C8898210 /* SK1Storefront.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4632275F8ECBCABA3EF959CB510B50A6 /* SK1Storefront.swift */; };
+		3B259F23B524EA8E35BFDA1E31412FF1 /* PaywallData+Default.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D0D558FED95668F69D2BDAC461E7337 /* PaywallData+Default.swift */; };
+		3B26260ACB37710A387C59887AB4362C /* RevenueCat-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = EC46D683AB4593573D11FF6681C5B5A4 /* RevenueCat-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		3BFE12BAD1BBF015E454C58A671CD150 /* ProcessInfo+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1EB560E06C3561F232AB47F9DE11659 /* ProcessInfo+Extensions.swift */; };
+		3C07B9CFC365A65446B9C6FD0D22CC9F /* SK2BeginRefundRequestHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 334E024B920045978835E0253D39407D /* SK2BeginRefundRequestHelper.swift */; };
+		3DFDC063E8D9B4CF647ED7A2D312C39F /* icons.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 8A0B29E7788D6873A17E04AFA7EBCE23 /* icons.xcassets */; };
+		3EEBA761A55B92B45B1376A9B93D6549 /* ConsistentPackageContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A9FBDAE0B629A66FE29A3CC6BEA0FFC /* ConsistentPackageContentView.swift */; };
+		413AE853EDE5AD449A3F5CEC5A47A21E /* TemplateViewType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F3323B15F06428E6B106BCCC35F99DF /* TemplateViewType.swift */; };
+		420E8E1CF31343BD2955C5F5372DBA74 /* OperationQueue+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3333D851B66855FCC88037DA067972F5 /* OperationQueue+Extensions.swift */; };
+		42728C5AEF0D78F4E79E7B6446814F0D /* PaywallStoredEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E20C245A924BD3C35AB64A1D16C417B /* PaywallStoredEvent.swift */; };
+		42D26A54A291FC8B274F2F2670D33C2D /* SK1StoreProductDiscount.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FF4B2CCBE3A9020A6F6BE3EF4A4EE0E /* SK1StoreProductDiscount.swift */; };
+		434C91825EAE74E9C0F25EC7E8363BA4 /* PaywallFooterViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE78FC7AF28DDEDFBDFA9C66A5CA05D3 /* PaywallFooterViewController.swift */; };
+		4367F2B0D836707B0A6464F87F770859 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 51B9931DD3FB99019456617147804449 /* Localizable.strings */; };
+		44DE668C93D581EA4C06879D2C9227A5 /* NetworkOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93E73B891FAE8B5450B4F7FBDE77C30D /* NetworkOperation.swift */; };
+		44DFC9C082DCDBF87065A198E4AD0088 /* UserInterfaceIdiom.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65D5E2CD27BF5A77B217D577012536C6 /* UserInterfaceIdiom.swift */; };
+		4621EA2EE7C665DD06AD35759377DE95 /* MockPurchases.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5830B063A00F011FD05D7453D10BF423 /* MockPurchases.swift */; };
+		4684B08141405A68F0BC3A67FFC4EE5E /* TemplateError.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB6AFAAB6438F6F1C4A40622ECDF46B9 /* TemplateError.swift */; };
+		47C6A1A024C75EA32F90AB90B8C6021F /* Clock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77597392A7F0B2A81AC84D5C39E107E9 /* Clock.swift */; };
+		49C15EACBCBE3E391D2225D18E573712 /* PeriodType+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 962024FBFCFC7841404BE1BFB84163E2 /* PeriodType+Extensions.swift */; };
+		4A5C6194F50594F285070D22A159A085 /* ProductEntitlementMappingFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F151C45B517CDAF823A8E8FCC2339DD /* ProductEntitlementMappingFetcher.swift */; };
+		4A768F3A88648AE6B13D79C2F64903ED /* RedirectLoggerTaskDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F862FAF96D5F54F1F5C3E95CC4EA5F1 /* RedirectLoggerTaskDelegate.swift */; };
+		4C35BF92CAC799F7179383E37EAB1B20 /* Operators+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = B05238CFC05F5888B303CB4B9AD99B68 /* Operators+Extensions.swift */; };
+		4DF194FF183314B10301D3EED35A28A3 /* ErrorCode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06E5399767DAD7EA0AADC5104A54C55B /* ErrorCode.swift */; };
+		4DF95AE313D4F1A60B5239E4EC9C19F2 /* StoreKit2TransactionListener.swift in Sources */ = {isa = PBXBuildFile; fileRef = 457785D495E608B772FF2A41CF66CDED /* StoreKit2TransactionListener.swift */; };
+		4FA4651BF832A1AFDF32F60512D4562E /* Either.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6843F70FDDD5F5EA8EB0C7BFE1393CA2 /* Either.swift */; };
+		500AEFEB5120ABC8B0B6D47AAB31E257 /* CustomerInfo+NonSubscriptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CA8CBFD5F5575535E02F38D5A390DCE /* CustomerInfo+NonSubscriptions.swift */; };
+		518E8DA59A238563764C753133606A4E /* ProductEntitlementMapping.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D5DDEB1136F23F125C6FAF1C669B61D /* ProductEntitlementMapping.swift */; };
+		52FA5C4F75DB8BD88D92EA9202210E6D /* AppleReceipt.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6436F36D08B15F4C86F4489539F0EBF /* AppleReceipt.swift */; };
+		53FE1A8238B0A54247D5197495188037 /* RevenueCat-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = DCA9E79A59113D86C1186ADA0D1E5108 /* RevenueCat-dummy.m */; };
+		5572692C2A0E324FE0020CCA2E5416B8 /* Signing+ResponseVerification.swift in Sources */ = {isa = PBXBuildFile; fileRef = 715411EDCA987814596E51D5D40C173E /* Signing+ResponseVerification.swift */; };
+		55ADD8B6EEE9E7C99DBA21D31C0DC75A /* PurchasesDiagnostics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C0848DD5307985FCBF2D148277E556E /* PurchasesDiagnostics.swift */; };
+		55C7E4386448503A64D078A40C374130 /* ProductsFetcherSK2.swift in Sources */ = {isa = PBXBuildFile; fileRef = D71FBFA350BE6E2A0AA1EEB91BFA3DE7 /* ProductsFetcherSK2.swift */; };
+		5637A13A81CBB3610CFD55DD041B06BD /* Lock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8806DD886666D23BF01A025A15962DFE /* Lock.swift */; };
+		566401378CE4C729B3DEAEDFB042D622 /* HTTPRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9313E4468561E9486B77FFA016FC1F5C /* HTTPRequest.swift */; };
+		5792629765090E66BD8AE8EEA974DC43 /* PaywallEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4837F9FEC3E3C7809E628FBCA94EEF67 /* PaywallEvent.swift */; };
+		57BAD5966B4C05D3628364CA5B5F2DCF /* InternalAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = B589712FC557590325C8CCFF2B81BC16 /* InternalAPI.swift */; };
+		58419EB2A7BE69BB90E718F7AAF7DED3 /* PaywallEventStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB481D2492ABB41E4FA555A662785F3C /* PaywallEventStore.swift */; };
+		585D0177F0EA19D8F2ECEFB0C87FF435 /* PaywallPurchasesType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CF3C1E92A5A1BBBF9DB188C96E1B029 /* PaywallPurchasesType.swift */; };
+		58CB0C5AB2A6D3B8BD77E78FD7D14F5B /* ErrorDisplay.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6C0C4A916C327F7DF923E7B5D71D5CC /* ErrorDisplay.swift */; };
+		58E519B66767D9111C2548FB8F285600 /* DateFormatter+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C2FFA9D4E6ECD228EEFCD6C5AA96B39 /* DateFormatter+Extensions.swift */; };
+		5A001B5EC5EEA78DFAB1B4D843F298A6 /* LogIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB79074395CA71664B624679C88EC9C3 /* LogIntent.swift */; };
+		5A18E8698E9269256B6B39E6B05EE39E /* Purchases.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01C6E8CDE817B89AF6687351BB2E760A /* Purchases.swift */; };
+		5B0525EFAA8EFB32AE377531BA05D006 /* StoreKitWorkarounds.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC999C381929373550AAA80279F27C52 /* StoreKitWorkarounds.swift */; };
+		5C491C76832E864DE5F50E87F667C7FE /* HTTPRequestPath.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81631C437A3D05C00ADCB40149D88AF3 /* HTTPRequestPath.swift */; };
+		5D1947DCB168D86F60973656DB5846A0 /* ManageSubscriptionsStrings.swift in Sources */ = {isa = PBXBuildFile; fileRef = A569D3AA76244AC8088DC50D766DB809 /* ManageSubscriptionsStrings.swift */; };
+		5D7E5164BF6AD6F21154981825C58752 /* ProductEntitlementMappingResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5268F6651D7ECE855E7A42C8C4EC7C99 /* ProductEntitlementMappingResponse.swift */; };
+		5DD48D3A7455E995B0251F98B2E1C37C /* AppleReceiptBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBBC56A8E1AFF6F6AEEDD1B5FEEC4251 /* AppleReceiptBuilder.swift */; };
+		5F9AC59D244FB3B33674769F0920EE93 /* CustomerInfoStrings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85E13D987593242F795289E45796ACA9 /* CustomerInfoStrings.swift */; };
+		60143BEE051335B71E4C0C4240D08AF3 /* AttributionFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A598E5E0F263DBE91FD61575F46786F /* AttributionFetcher.swift */; };
+		606CED778883CD47B006E4E90F1BC866 /* PurchaseHandler+TestData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3597BF99FB7D38A634D97D665FBFE1A0 /* PurchaseHandler+TestData.swift */; };
+		610C7DF1EF543B3DEE37674D60B56A7B /* Strings.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAA6F4DB54FE48AC3E186008A105709F /* Strings.swift */; };
+		633D9C408CF785E33057B811D5A305A1 /* AsyncExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 034DECCA994D46B6BCED9C208E232D60 /* AsyncExtensions.swift */; };
+		63AE7F9A21CFB3FBFA2E363D9446A05D /* IdentityAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = B002E4D329D936DC8C0D24C71702F403 /* IdentityAPI.swift */; };
+		63F6392F4F935A69D91725F62A12BCF6 /* DiagnosticsStrings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4560C1E5ED8F09031BE6D4B5B5CDF727 /* DiagnosticsStrings.swift */; };
+		64CA57BD7FDA534F45B3C006394AEF59 /* PostSubscriberAttributesOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = E465680BCC264263781260D01F710AC7 /* PostSubscriberAttributesOperation.swift */; };
+		65606197C80DB4E107B9E2C6D597196F /* UserDefaults+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 049DE7D491B9ABFCDEB8331755E541C2 /* UserDefaults+Extensions.swift */; };
+		65EB3BC7B69004F127C81AC90211F392 /* InAppPurchase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 987465897488AC3AB163EA8DFCDFF86C /* InAppPurchase.swift */; };
+		663626134FC58CBBCA51C8D5EED8A65A /* ASN1ObjectIdentifierBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6615C5A368D81A525045230D4EEF894F /* ASN1ObjectIdentifierBuilder.swift */; };
+		6690AEBD1698E589EDC2D47503684148 /* VersionDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4949EA4DC67310D8339EFF214B672911 /* VersionDetector.swift */; };
+		66C60CBE497CF1F8FD279D8C20D51A36 /* HealthOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1F5C2C607E66A6374454EE05BF24E31 /* HealthOperation.swift */; };
+		66F74DA753E22121AFD9970143F64621 /* PurchaseOwnershipType+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDE874B719E1D43667CC22191CE22C82 /* PurchaseOwnershipType+Extensions.swift */; };
+		681824ED0A261A9B7CE4EAC55C07218C /* AnyEncodable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8460F8943928A50639622E13E5EADFB6 /* AnyEncodable.swift */; };
+		683F5A57E457AE89E32760F2B2E3FAFB /* Template4View.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06E245E6676726EB6576F1AC42ED9278 /* Template4View.swift */; };
+		683FB8C4C8AA3F20BCFEB550B466BB17 /* PaywallHTTPRequestPath.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3858205357F8B2DDA9C988D7AABA7489 /* PaywallHTTPRequestPath.swift */; };
+		689CB0CFB2B95318525371132D3E5B63 /* SKError+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90D5BA2A086A5A3874581563CD5206B7 /* SKError+Extensions.swift */; };
+		692DCF2D7D2A382F49576632146A5D4C /* CustomerInfo+OfflineEntitlements.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0052237C8F47C201B87019F8E3B3D4E9 /* CustomerInfo+OfflineEntitlements.swift */; };
+		6969D358F70DBAA1450E7E776DAF96D1 /* FooterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23CEF064C5B5ABF69F1ABBA1ACE5B1AA /* FooterView.swift */; };
+		69CC1F8DFB6E8F76C9CD5050CB21C3E1 /* Date+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89F546C6D8FA5F5AE01F6E6686A69AA9 /* Date+Extensions.swift */; };
+		6A17767C71AD6AB533E877BFD6822061 /* TrialOrIntroEligibilityChecker+TestData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8745784440E8D38B132D52D48EF29B1D /* TrialOrIntroEligibilityChecker+TestData.swift */; };
+		6ABB81A1917987E5C4F8E9CA9358B635 /* EligibilityStrings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F8A9C1F4DF9F62BD23CFF55676028E1 /* EligibilityStrings.swift */; };
+		6BF14FFD1F282148DBAEA98E2D44249E /* ProductRequestData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C17E266D5A3121C791A3F4D7D01C54D /* ProductRequestData.swift */; };
+		6D183093E65493328CFB160CE6327D6E /* ReceiptRefreshPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E6DCB7DC4901FD63CCDDAE222A20EF7 /* ReceiptRefreshPolicy.swift */; };
+		6E17AA1CA5330EBB598B56C9B75CFBCF /* StoreKitError+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB6855FC01EDEF698EA925CCD5718546 /* StoreKitError+Extensions.swift */; };
+		7012B7794DD20785FF28FEE1727CF443 /* PaywallCacheWarming.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31816E7AF5B16DE42937CD24ED83E20D /* PaywallCacheWarming.swift */; };
+		705FFD5A68DB23A9AC7797B3A57B2F04 /* RevenueCatUI-RevenueCat_RevenueCatUI in Resources */ = {isa = PBXBuildFile; fileRef = A11ADE067B216AB469480C2DE84D2D31 /* RevenueCatUI-RevenueCat_RevenueCatUI */; };
+		706B6D6EC39174B5FE3F5706FDF3107E /* ProductsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C0E330B41826951A072A6A252EE374D /* ProductsManager.swift */; };
+		71D0D280CC771B6C048981820626F0BD /* BackendErrorStrings.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFD2BC0CAD3FBD8C1838A8DC2C976B90 /* BackendErrorStrings.swift */; };
+		72B5D5D96F902D701CC5294C5B072A2E /* DebugViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1628C9B7F9C3B39A0EE2661659144691 /* DebugViewController.swift */; };
+		72E14CFE12B48A650433B3A1034CF260 /* View+PresentPaywallFooter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F1BFCA3528D7022573FF89003AA31BA /* View+PresentPaywallFooter.swift */; };
+		72EF1B42497BC4FF0E3266F0643B3F81 /* GetCustomerInfoOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B0C1CD9109C6C6934435F40D7566338 /* GetCustomerInfoOperation.swift */; };
+		744F0EFB24B4A355F7EE890A22DD5030 /* MapAppStoreDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 998DBC62E94BC55964B527144787C753 /* MapAppStoreDetector.swift */; };
+		745C430B8C7CE236DFDD47AC83625D53 /* ReceiptParsingError.swift in Sources */ = {isa = PBXBuildFile; fileRef = A13404049810AEB8A84735E0B3F234AE /* ReceiptParsingError.swift */; };
+		7493BC98044DCF9E94EF8BB32F7E46CE /* StoreEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1AF82E31C65331D8A1A6CD1B3D40CB50 /* StoreEnvironment.swift */; };
+		755D65A6BEAFDB508C65C93BB96FB69C /* TrialOrIntroPriceEligibilityChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E46233E5702053711B7E54132935CF3 /* TrialOrIntroPriceEligibilityChecker.swift */; };
+		75630DA32FC7A42190FA7960423DC20D /* StoreKit1Wrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38A77254A36685B116565ACACF9116A2 /* StoreKit1Wrapper.swift */; };
+		759C731E338479330579BF01FD112962 /* HTTPClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1D9E89535C03D64F3626746E85A7662 /* HTTPClient.swift */; };
+		7615764633FFD660170E78A519BCED76 /* ETagStrings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C18DEAA6661BFE23A38B1CB3BFB940A /* ETagStrings.swift */; };
+		7695012922F54E380F6419A495102C09 /* ASN1Container.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DE9CD47D163261AD58E749451BDD743 /* ASN1Container.swift */; };
+		76BAB046F6EC9184EF17C6A49FD7D9FD /* LogInCallback.swift in Sources */ = {isa = PBXBuildFile; fileRef = C00076B3ACF9832943483521408B1282 /* LogInCallback.swift */; };
+		770B7FBA1C3994BC3BEEB3C585B1AB43 /* DescribableError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13B0CB406CF2B1448F56735252C8D71C /* DescribableError.swift */; };
+		776CFDC4A39B996A5C22F336A45A66E9 /* PaywallViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A54F2FF9E0100C23B0FBD6175AFDB57E /* PaywallViewController.swift */; };
+		779B1585AA6BAAEDF50AD841C045FF5B /* SK2AppTransaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 700B7847A5AAA7AF5105CD1019B84002 /* SK2AppTransaction.swift */; };
+		78C6740C70B2A0A4B268FC49318BF0CE /* ErrorUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B7394E4FA5715231A66BECB05871209 /* ErrorUtils.swift */; };
+		79180D5F2F19AC3E848B5F2DBB964604 /* Data+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97D0D1959F6DD6F6AC29861544009780 /* Data+Extensions.swift */; };
+		798CE2918FA9BDEFCAD4E62804A58BEE /* HTTPStatusCode.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDD87483360DAE06679FC5FF83BB9B92 /* HTTPStatusCode.swift */; };
+		79C050535DB11F3C3AB016FEFF123ADE /* PurchaseOwnershipType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23D8FDF2B1102058AAC884CE43EDA0D0 /* PurchaseOwnershipType.swift */; };
+		7A341060AA74930FDA76018A2BAEDDDF /* Codable+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = E84E49A66DC290DF15DE0BD29E3C5F63 /* Codable+Extensions.swift */; };
+		7D05D94732A29F90E71F4784E9F2196D /* LocalReceiptFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86AC49434CFE36F0364007173F6A9496 /* LocalReceiptFetcher.swift */; };
+		7D1AB04D1AC1AF9979C4920C7C7C6426 /* SK2StoreProductDiscount.swift in Sources */ = {isa = PBXBuildFile; fileRef = 605FAED5A8B4D8E8444DE897D121B3BC /* SK2StoreProductDiscount.swift */; };
+		7E2CF18E4FCA5A46DC1A793949F10C89 /* Variables.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA3DD4E616BD75B704078BFBEDF6469A /* Variables.swift */; };
+		7EB0FC2BB878FAEA733EFBE6EAC5AE6B /* LogInOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61CF97E5EE29C235E2D75FBFC1389782 /* LogInOperation.swift */; };
+		7ED6B3DB4C15C3B9D270722AAEC69095 /* PaywallData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14B426F1B92DD2C66583E6C29D7B01B4 /* PaywallData.swift */; };
+		7F8E44A49BA404A6107E77B935F32AB8 /* OfferingsCallback.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6321ABC8B416568CCD2ABFFE29455F67 /* OfferingsCallback.swift */; };
+		7F8F6913F886359FAFF10AA128DA6601 /* FitToAspectRatio.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC110E03FF4B22E124E1A6E1263FC0F8 /* FitToAspectRatio.swift */; };
+		80499DEA76BB669B0E9B248B9500E3F9 /* Set+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E8EEFF0916467A473EDC2705419D8AC /* Set+Extensions.swift */; };
+		80F2AF677EB01356FCDE19243F281DB5 /* Atomic.swift in Sources */ = {isa = PBXBuildFile; fileRef = E77BA889ABE506F57687B5A3626D83A5 /* Atomic.swift */; };
+		80FD25A5427DB626FDB73E1015F5E73B /* Result+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68518B3344CC25984CAFD8D47D65FE6B /* Result+Extensions.swift */; };
+		8231B1E460FA9E9CB7FD6E7F085B76B8 /* Purchases+nonasync.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE25FA99DDBA18EB97347F9BC48B2496 /* Purchases+nonasync.swift */; };
+		823570F6D8FCD3E7DEB0815E0F07A6E4 /* Template2View.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2145099333FBAEEB8A7DD4BC2ADB176F /* Template2View.swift */; };
+		83697BC1BC0BFAFA3BDB86D8D8990F7A /* Pods-RevenueCatUIProxy-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 77AC2BFEB533A0A7A27733B4D78DF05B /* Pods-RevenueCatUIProxy-dummy.m */; };
+		8379CB389751154716719DE9DDE0BE3D /* OfferingsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 840E180E3D822EC9EAC7942B662A1ADA /* OfferingsManager.swift */; };
+		843EA1027EBB93E5AB07166D21C2479D /* OfflineEntitlementsStrings.swift in Sources */ = {isa = PBXBuildFile; fileRef = A812827A7A0F5D1DBDB11B06E4075936 /* OfflineEntitlementsStrings.swift */; };
+		84A2D71B4FAED24AFB16358E4AA0BD7E /* PlatformInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4D6545B930EC5A096110298738AD951 /* PlatformInfo.swift */; };
+		84AD057E9F08914BA6774CCE1029715A /* PurchasesOrchestrator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20ACED2DAF329A74B31102084342FB10 /* PurchasesOrchestrator.swift */; };
+		868C3567D442B5AE72617F057C90779A /* Bundle+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04DC4F5D389AE04EEDF3898FF00F04DE /* Bundle+Extensions.swift */; };
+		8BBA67B9DAFCEF8622C74D4554F61DBC /* ErrorResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = D89BA3BEC5F6718F547544EE09B8523E /* ErrorResponse.swift */; };
+		8C71AC74BA64E5B5A97AAAFB1F6132BB /* CallbackCacheStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7142C9AD45DFD689443A103A599A3693 /* CallbackCacheStatus.swift */; };
+		8D105072C0EF6F8B0696D2C1721AB8AD /* SynchronizedUserDefaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = 017BDCE2D2662FA6A493CF1BFB25B6A4 /* SynchronizedUserDefaults.swift */; };
+		8D547D8F179B768586470F89D3F11BF8 /* AttributionNetwork.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21C1E1098345081ABAF01BA2A8E876FB /* AttributionNetwork.swift */; };
+		8E6A24415060C355E8D7E412DB756439 /* Decoder+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E454A81509B8947AC746BB2DACF1D90 /* Decoder+Extensions.swift */; };
+		8FD20BD52F73387E48BA13FF98025B01 /* SubscriberAttribute.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6789762025A2E63C850219BA1FBC82D /* SubscriberAttribute.swift */; };
+		906EDF1729E8927648F1AD4C1616B36C /* BackendConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9006E032BABD4A5FA569CBDE9DCC55CD /* BackendConfiguration.swift */; };
+		93B530215BE4238E2DCB6069D6ED44C6 /* CallbackCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4922199D5683E03888AE7BCFADB60703 /* CallbackCache.swift */; };
+		944646D1BA8A645D9FDCFF3E9DA2858C /* StoreKit2TransactionFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C00696A7C38211D433C22DC147D2264 /* StoreKit2TransactionFetcher.swift */; };
+		94AF9164BCE38CBC4D2598F7543A2E31 /* Error+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14A5ACBE79C0A9EF7DE745D39FE974A0 /* Error+Extensions.swift */; };
+		9557337EEC20924FED588CF84EF535DE /* CustomerInfoResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8474631B52639B79C38E81B8668CCDEB /* CustomerInfoResponse.swift */; };
+		960E364D055D70DF34B2ADF84E895CC3 /* PaywallViewMode+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EE436FCBE03A50CFE0BFDED3248991D /* PaywallViewMode+Extensions.swift */; };
+		96D4E23AD8700BF590A344EE49AED9A7 /* Logger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9325999737B5A2ECFC64CFDFB1E93231 /* Logger.swift */; };
+		975406B672E58D7233B74CD4DE2C7BC5 /* Backend.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD727195107FE62E1616C528C7887982 /* Backend.swift */; };
+		98FC0FCE8B007215A3B07B98926B6465 /* RateLimiter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 765E212E32A562E75433380D634AE665 /* RateLimiter.swift */; };
+		9B3A84588B27929B803B7239243D4626 /* PaywallTemplate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41C9477D371661E8E7C3BF93A1434D74 /* PaywallTemplate.swift */; };
+		9E28C7230552FFD7736FF4683331B5A9 /* ProductRequestData+Initialization.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2348A832CBA44EDE63364DB1986FB60 /* ProductRequestData+Initialization.swift */; };
+		9EE7E67663FF49916B65A23C30DA5304 /* DebugContentViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = A79B480376A49072749C3E326B72CDA0 /* DebugContentViews.swift */; };
+		9F48C29AAAFC9E12840543EA9CF8D3DA /* PackageType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A4E0B1ED911611F228210AAB8F55782 /* PackageType.swift */; };
+		A0FC8B90DF9C9E2624B0FA1C0C8EB873 /* OfflineCustomerInfoCreator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1765ADD1D0C7468CC4CC8B7EA3E1FD09 /* OfflineCustomerInfoCreator.swift */; };
+		A1AC2A39E9CF873FD4AAA4D4FCDF3882 /* TemplateViewConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 769EC5FD932E66F04E09F83EBBA8302E /* TemplateViewConfiguration.swift */; };
+		A28BC44E5638409C03CAD70B04A39611 /* OfferingsResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99BAC9ABF5F87CE3AFBC4044FF5EC559 /* OfferingsResponse.swift */; };
+		A2F8047CFE227730D9DB9071DAB1794C /* PackageButtonStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E48A52143B096EFAC48DF76EB9AB992 /* PackageButtonStyle.swift */; };
+		A2FD2A12CBD2974FA69727F9F3A5697F /* Offering.swift in Sources */ = {isa = PBXBuildFile; fileRef = 372EE7ABE674EA19272F3A4F0FC6DDF3 /* Offering.swift */; };
+		A30AD567E84A08A69EA3E79F8CA68CF2 /* AsyncButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E2CAC070D3FD34A0B997D67849A9651 /* AsyncButton.swift */; };
+		A3476386630864499AFC51DF4690ED5B /* PurchasesReceiptParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = D591E6468FEBB719BED28B96D1C37306 /* PurchasesReceiptParser.swift */; };
+		A3559021C6D19365E6EE932362575834 /* PriceFormatterProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = F89477023283EA4BA1BCF6BB20B5861B /* PriceFormatterProvider.swift */; };
+		A381BE3EEA3C20A5ACDE89B74ECA44CF /* OfflineEntitlementsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD02133AC320927349A99B77213060B3 /* OfflineEntitlementsManager.swift */; };
+		A3F0CC54C5A279B65D85FEFF65A86AEB /* PostAttributionDataOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2FA6AA89A40241CD24FFB5E11FC65BD /* PostAttributionDataOperation.swift */; };
+		A4DEDD07C40C8384BE53BCD3653727B0 /* ProductType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A14D5B64519109F3593E787ED24ACCE /* ProductType.swift */; };
+		A82734DD680B295E12144D5FEB24F4EF /* Offerings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D8FAFBA4428425593792C6F0847CFAC /* Offerings.swift */; };
+		A858B521D3928AE7B04E9D587EBBE00E /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 45B01B021164958A1A1625CE10CD6777 /* Foundation.framework */; };
+		A85F3B407EF32ED277DBBDAB22ED8188 /* PurchaseHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0C6CF786FCE8C4758D9195D48CDCF5A /* PurchaseHandler.swift */; };
+		A8A0DAAB2C68B1BC240F62B8FC5AF8E7 /* StoreKitStrings.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE1EEE7DABC48AAFE5903AE56EE0E86B /* StoreKitStrings.swift */; };
+		AB6E10FBC820B5EDB286F76CE2106D11 /* Array+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5371208E84A3229D8B19F9E8DF380A5 /* Array+Extensions.swift */; };
+		AB95012CD75ED95B2933A431F34F647C /* AttributionDataMigrator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D4BD6CCCEE68209D38D974AC89C2FE3 /* AttributionDataMigrator.swift */; };
+		ABA5147D0095962DB0E655B418648386 /* PurchaseStrings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6684D4C6BC54402CB322B27DBFC2F379 /* PurchaseStrings.swift */; };
+		AC76F375998E3C41D84AF99A38163961 /* HTTPRequestBody.swift in Sources */ = {isa = PBXBuildFile; fileRef = A60EFCC74E5629D9B30E5DE6D6A60F2C /* HTTPRequestBody.swift */; };
+		AE16A900AF4454AF873F9E96CF2B1951 /* ErrorDetails.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC4549FC46AE7A6492CE90C1D4DCA23 /* ErrorDetails.swift */; };
+		AEA7B194E7CB20CCC65C55E3B677D7B5 /* FrameworkDisambiguation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EF63ABD9CCDBA84E50E3E8EC01DE837 /* FrameworkDisambiguation.swift */; };
+		AED9184FCAF5F0E6F85193297575DD87 /* AttributionData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46B538D4275ACB6D2A16D4ECFE619F44 /* AttributionData.swift */; };
+		AF147C181DEE04C0EE49F5EF366FAA60 /* Deprecations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43B64DF06A7ED3B998E74B51AF14BAFC /* Deprecations.swift */; };
+		AF680C6DAC773A6EF23D652160C0B740 /* PaywallEventsRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = ACD66A2D1313F92B3A877AFECEBC33D7 /* PaywallEventsRequest.swift */; };
+		B05A51AAB643C2B77DA117C9ED226FF0 /* Integer+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53E24F8FE1375A9E933203DFC5C06759 /* Integer+Extensions.swift */; };
+		B06CCC598FF7FA8D5C5806EB5E96429C /* DefaultDecodable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 222131C342DD6835365FA5048A996250 /* DefaultDecodable.swift */; };
+		B1AC3B0AA7DC642CFE65A04D220B54C5 /* FileHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAA0E732FEE7141F24E3F4E7A5A773FD /* FileHandler.swift */; };
+		B2AB2F4414EA5BBE70DB8496EAED9E89 /* UInt8+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55A776A74CE9ADEC37DA5F29D75DA961 /* UInt8+Extensions.swift */; };
+		B55D8B07D06AAC6B9A7763ADED84F288 /* View+PresentPaywall.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AC17DB80457EE71A6F77CD47E80A6CC /* View+PresentPaywall.swift */; };
+		B5922E8782EB26AA79C30F0C227C308A /* SK1StoreProduct.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03A3FC674FBD50C2ACF0FCAF4A1715E4 /* SK1StoreProduct.swift */; };
+		B6731BF374FEC97B40D373A424003905 /* AttributionStrings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FDEBCE68D047156CC4491F401F822C0 /* AttributionStrings.swift */; };
+		B6E0549837C0A724F07A38D30436AEA3 /* IntroEligibilityStateView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8FC9D7C0BFA6196FDE4E2F548C4ED78 /* IntroEligibilityStateView.swift */; };
+		B8C50B35F7DAF0B7FCA39FBB2A9F2641 /* StoreTransaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E99153681E0D8F6D4C642F824A866F9 /* StoreTransaction.swift */; };
+		B917C6418C8414D5AA2BBCF4F770D740 /* PaywallData+Localization.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9E6AE1E820BAD23D10A3D29AB732089 /* PaywallData+Localization.swift */; };
+		BA3BE53D34E1BDFB1433FDC91F2CB37C /* IgnoreHashable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DE57DB635EA829EBEDA10D7FBB436F8 /* IgnoreHashable.swift */; };
+		BACDAF7CBB48CF2B08730163D01D2928 /* ISOPeriodFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D773688C1E38F7BD47217D67B401202 /* ISOPeriodFormatter.swift */; };
+		BBC227210D9DCC76F8CE223C2E39B9A9 /* ColorInformation+MultiScheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = B13710EBD419656B8ECE1A32CD356ABA /* ColorInformation+MultiScheme.swift */; };
+		BBEEAB972B345897894C4627F05455B2 /* ManageSubscriptionsHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D9E714CB697615148A5906730122F42 /* ManageSubscriptionsHelper.swift */; };
+		BC30DA2FD53B912E4DE73B45E199C58F /* TransactionsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B6A4EABEDDA29B13EA2006FBDF9F895 /* TransactionsManager.swift */; };
+		BC7E41841487F2CB2DBBAB3D35266B2E /* PreviewHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34034DAE3C091E4478F25FCD36D74A3E /* PreviewHelpers.swift */; };
+		BCF7D29E788E4F96655172DF8B021B7D /* SK2StoreTransaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = C886F097E968C8A7A5E40F85BF4EA750 /* SK2StoreTransaction.swift */; };
+		BE7587F529ED62A5991FDC7F4F07B52C /* DateExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = D42E1CB6DF06A1988C5DB694EEE4A725 /* DateExtensions.swift */; };
+		C10CE71AA94DE6C7E3049248C69B1C42 /* TrackingManagerProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2204801CE2EC17213FD239AE398508E4 /* TrackingManagerProxy.swift */; };
+		C18DFD24F9B6EA9FCE44A541CFC395F4 /* CachingProductsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9321B7F3F9A2EF3DBB5683904363FB45 /* CachingProductsManager.swift */; };
+		C19C89CC60C10106B2547B35EA498137 /* GetIntroEligibilityOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32F5E6BC7E0B3F3B80716DF65F718732 /* GetIntroEligibilityOperation.swift */; };
+		C1DECD1C6C0A82DEC1D090ACF573D045 /* DangerousSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5AC7FBFD03B895826FC614C4E933170 /* DangerousSettings.swift */; };
+		C31DBA526D34B4E4AF18E978B9B20DB9 /* CodableStrings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CA9CE285EAB9403D4FA61784F244DD6 /* CodableStrings.swift */; };
+		C3A41CF0BFD30A00DCFE730BB204C80D /* BackendError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 775B974FC4B89E31A32A3BEAAFA3714D /* BackendError.swift */; };
+		C4401AFE9E4153EC5126EE527F2C3704 /* IdentityStrings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25FA20A35B1C18890DA652125D391EAF /* IdentityStrings.swift */; };
+		C47619F9C4EAEE421D5051B9996BA832 /* AttributionTypeFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA0CA1344A1BBEA20F49B33D6CFA80E4 /* AttributionTypeFactory.swift */; };
+		C4ED41CAF0F296BA34512DD3B1095490 /* ConfigureStrings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0419E764195EDDC1046E8940A59B8985 /* ConfigureStrings.swift */; };
+		C519EB99C7FD1114DF43714358BCB02C /* EnsureNonEmptyCollectionDecodable.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE8846676500151FA6F56619CC13D4BF /* EnsureNonEmptyCollectionDecodable.swift */; };
+		C57BB681941DFE76D6798F52FB96F6D4 /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC84B2418BCFA843623765703ADA8A18 /* Constants.swift */; };
+		C5E4DA3234DCA6436F8693C365E49790 /* PaymentQueueWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = C17E96ABEE65166EC8F3D05DE6AE7629 /* PaymentQueueWrapper.swift */; };
+		C6C6758EC512B4B0FC8B0B4E598F8918 /* NetworkStrings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71C54285A3DD42FF51B4474B47AE9E1D /* NetworkStrings.swift */; };
+		C70BACBDD54514C7B85E98AF04725F19 /* DebugErrorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F7240EE6A5EFE74509BD484A0588DF4 /* DebugErrorView.swift */; };
+		C8196A45C6DEF1335789C861C4BA6E6D /* EntitlementInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86D50AFAF70D472CCD93816B32E1E40B /* EntitlementInfo.swift */; };
+		C81B61E806BE647EE927CA8E7165DCF8 /* LoggerType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 689F831F8BE8C1B1C6C08CC4223E7C0B /* LoggerType.swift */; };
+		C9068AFD0FCD8C16B32C5A7729937E9B /* PaywallColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4D4CC263A6389E17856A6F7789920C5 /* PaywallColor.swift */; };
+		C97471DEF21B3B67D011C28C8DB1A421 /* PostOfferForSigningOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CD58377164B1105465F5DACD097B975 /* PostOfferForSigningOperation.swift */; };
+		CB2644A73AE15E0BE7F671FE8019B4F4 /* StoreMessageType.swift in Sources */ = {isa = PBXBuildFile; fileRef = B40E63D923368F867FC605BEE247EE5D /* StoreMessageType.swift */; };
+		CBACB0D2FBA082BC9F38427CA9E9C20B /* EncodedAppleReceipt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E9AFF147D2310B1DE529DBBA90B216B /* EncodedAppleReceipt.swift */; };
+		CC1A46FC7337A2FDEF6C453B51B5C527 /* GetIntroEligibilityResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 585C576BCECE23BC51069949ED78CBED /* GetIntroEligibilityResponse.swift */; };
+		CC28AE340ED621984C4D629E3B681216 /* SigningStrings.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7EFD14B0A93572C43C2D13BB54CC923 /* SigningStrings.swift */; };
+		CEB1CC996909F329817740F4E293F46C /* ReservedSubscriberAttributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5C93B916C65C38399E62D9C60BB33AA /* ReservedSubscriberAttributes.swift */; };
+		CEE3C8588A47C6CA36F587FF455033BB /* View+PurchaseRestoreCompleted.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49DD941877FDE851657A51E48AD31B65 /* View+PurchaseRestoreCompleted.swift */; };
+		D010AB9308801FE83EC7DEA96AD0F431 /* EntitlementInfos.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7AFB393B2D5C4E4FEEEE40ADC65E6934 /* EntitlementInfos.swift */; };
+		D032CE1D0E85260C922CC81909980485 /* IdentityManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF1D27EF667400D5DE4CEAAEFF862205 /* IdentityManager.swift */; };
+		D07230EC4E66D68E741DB88FC636F98C /* Dictionary+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C2554ECF1D573B9C52E9F96796B9A0E /* Dictionary+Extensions.swift */; };
+		D0C8F9BC51C80EFEDC59BF7C745000BE /* PurchasesDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D82FDC22586B0B4387FCCB4BFB50CD4 /* PurchasesDelegate.swift */; };
+		D1101E129A2B142B140986C499ABD2C6 /* Optional+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F7D68DA0D16CB2E56828F7B6EBB1CEC /* Optional+Extensions.swift */; };
+		D1263F58F2FB17D335ED4FFEE181CEA0 /* DNSChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEBAD9DFF50057516FBF8496F9AA3AD8 /* DNSChecker.swift */; };
+		D1C649D40A3C3FFD4824F693F4D14C35 /* ASN1ObjectIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CF406DD0954F76D42A36AA352494730 /* ASN1ObjectIdentifier.swift */; };
+		D23750B64D0C49CA0E8ED607507B1BC9 /* SubscriberAttributesManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C892F5517EDE2CCE92333D5214BF6C9 /* SubscriberAttributesManager.swift */; };
+		D3B056A4C39385889E87239A45ACF5DC /* CustomerInfoCallback.swift in Sources */ = {isa = PBXBuildFile; fileRef = F7AD91C1CD6F70BD092991445FA03F8B /* CustomerInfoCallback.swift */; };
+		D52BC7E08D1D4703E26CA134974B42CE /* OperationDispatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDBF93BBEBD6D0F518870B962042019F /* OperationDispatcher.swift */; };
+		D5983CC6DB244A8C3F98461E61628A0E /* WatchTemplateView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6569112F41AB17C8594AA45D46F8A643 /* WatchTemplateView.swift */; };
+		D5B19067E1F0461F6281A063A87457D6 /* Strings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C632E78406DB8D85F72A8B774394728 /* Strings.swift */; };
+		D7284A74D8AA61B76958B175A840AAD3 /* Package+VariableDataProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6E01D10B8A7F3609D7E429C35FC6862 /* Package+VariableDataProvider.swift */; };
+		D8F230E6A9BF696FC6B0C6A430AC9009 /* RevenueCatUI-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = E4A8C873408216E15B19A15C494031BA /* RevenueCatUI-dummy.m */; };
+		D98D8CDF18BDD0FAA3E4D8E97889D03E /* TimingUtil.swift in Sources */ = {isa = PBXBuildFile; fileRef = C927F3733C9038CED0547C8ED3B55006 /* TimingUtil.swift */; };
+		DA77F14FC0218ED9DA9C019AEFC5E621 /* StoreKit2Receipt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66710A8DB807A32CCF920B02C1218D22 /* StoreKit2Receipt.swift */; };
+		DA82B750C01991D8EB60F589F498AE0E /* TestStoreProduct.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80C436F8F9F838F0098B1C0CE04B001B /* TestStoreProduct.swift */; };
+		DC0DFF1026D1EB2D65DD13A02D990263 /* StoreProduct.swift in Sources */ = {isa = PBXBuildFile; fileRef = D04A7EF15B202B8A7A75501912C9494B /* StoreProduct.swift */; };
+		DC653C2632618AC52D482B25178188F7 /* DateProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FE85C9B0C62CB2237635DFC367C935E /* DateProvider.swift */; };
+		DCA9A5DAD72687BD449A882C6F421B46 /* SK1StoreTransaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80310C067C73962F88A6354DCE6F5564 /* SK1StoreTransaction.swift */; };
+		E1FC226DCFAB9486FAE9F4E36284DC0A /* ASIdManagerProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9DAE3BCB86E6AB6729DE0B9C56BFFB7 /* ASIdManagerProxy.swift */; };
+		E29885191F703C4860D3AEC0FC3A65B8 /* PaywallExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CFC3FE300E018D5A9F4DD6341661206 /* PaywallExtensions.swift */; };
+		E2B7EC3168B241AE139C1037EA31556C /* PaywallViewConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FAD6F55E6D19A33516999C74B213279 /* PaywallViewConfiguration.swift */; };
+		E34876956A4525BA22DDEB9BC7F0D723 /* Template1View.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EDBF31628D5E3EB2E2815F9A40BAD4A /* Template1View.swift */; };
+		E37064489140E47DAAA0ECE594C09D09 /* OfferingsFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99248F1D6403FEB9BF0D84404EDB4B0A /* OfferingsFactory.swift */; };
+		E3A4081EFCAB527C3BFC4D630D3BA87E /* PaywallFontProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = D19117EF24D1DEA008C42692B3DFB0EB /* PaywallFontProvider.swift */; };
+		E3C02CE07488C611F374FEE8C4D6A4C0 /* PostOfferResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 506856395E0C6776C54614F07BD6C60F /* PostOfferResponse.swift */; };
+		E43F395A8F3CF5CBA0A49B860A503D6E /* CacheFetchPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = A201EF114FEDA8084514827CE1AFF594 /* CacheFetchPolicy.swift */; };
+		E4822B1F27235D8A7D75EC1C6AA90916 /* HTTPRequestBody+Signing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40AE340C6D312EAEAA74A3262E66DB53 /* HTTPRequestBody+Signing.swift */; };
+		E4F5B96F03A5749492B456B6B1CE34A8 /* FakeSigning.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0101944FD91EA7AD3C015C203B23C41D /* FakeSigning.swift */; };
+		E5C227C894B0056531F6A22859CD2D28 /* AttributionPoster.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFF24DFA67346D283AEDAC36C87812F9 /* AttributionPoster.swift */; };
+		E700C167D875C4656F06AA24B8F50F2F /* DeviceCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44A9FA068FE7DBF0A30AD0985845010E /* DeviceCache.swift */; };
+		E74240672DE451BF3BB9D8DA628FBE67 /* ETagManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEFC8E12AF2C71A450E54827C67DCA87 /* ETagManager.swift */; };
+		E75ADF24236C11BA9C4E45F1996BCFF2 /* PostPaywallEventsOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 674F47EFB90EAACA6A5717B6E77532C0 /* PostPaywallEventsOperation.swift */; };
+		E7AD789D0393482A82B0F81A4A1EC07A /* ASN1ContainerBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5448EFDDD99FB7B52C918ED932A253F6 /* ASN1ContainerBuilder.swift */; };
+		E88F470BEB2E850D2FA669A75F9B6916 /* Signing.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2778FE803F904FE7F788822FC919935 /* Signing.swift */; };
+		EAA2D0030FE049B94B9CD240CE2C3E10 /* PaywallData+Validation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 873D800AA818919D9159417972EF4B6F /* PaywallData+Validation.swift */; };
+		EB0EC88C43067A29BB7825A1D5CC1C91 /* OfferingStrings.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB3F47EE27B2013E2728F6B6B1FCC10A /* OfferingStrings.swift */; };
+		ED02D2F07CB9DACBB1D423B554CACF3D /* BackendErrorCode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AF51E27768FD1642CFC3162DA97AB6B /* BackendErrorCode.swift */; };
+		ED46A473727AA5CAD9D4D85580788867 /* IntroEligibilityViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F06FA5B5D42E0DE0B76950C22E00DD3 /* IntroEligibilityViewModel.swift */; };
+		ED55B7BDFAF9C2B33EA2F2717C3697E7 /* PostReceiptDataOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80AEF9BFD1FACBC73E5CFDAA573C4475 /* PostReceiptDataOperation.swift */; };
+		EDD75759E0328CAB0E4E36E1B3CC6354 /* Obsoletions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 485D3A527946E757618BEC7D14F65D2E /* Obsoletions.swift */; };
+		EDDE58CBEC381F536694BDF36F11AB4A /* RawDataContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC9C2F019F6D720173BD6606CFACE663 /* RawDataContainer.swift */; };
+		EDFC76D560DF3ED39FA45686C83E567A /* PaywallError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 447660A1325B3D6BA209156F274EB920 /* PaywallError.swift */; };
+		EE609DFA7147F8934D9A73337658C97C /* TransactionsFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6B0C133844E5CDE425E8C36E87E7435 /* TransactionsFactory.swift */; };
+		EEF39DF17655E9B8366B550C7ABFC97D /* StoreProductDiscount.swift in Sources */ = {isa = PBXBuildFile; fileRef = 237F87F13D4BD6EF1C8B0AC49A8E9370 /* StoreProductDiscount.swift */; };
+		EFD9CCF9CD9388DA66B7D1553B4DE7C3 /* RevenueCatUI-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = AB4F48F4F073A35035B878CB24AC4A0E /* RevenueCatUI-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F008F1F786FC812131A15EEDA1E71CDA /* StoreMessagesHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CAF63F71AE6CF8C74E21584DBE6DF89 /* StoreMessagesHelper.swift */; };
+		F00C8FDAB14A43A49804B124B0CC9BDE /* HTTPResponseBody.swift in Sources */ = {isa = PBXBuildFile; fileRef = 621B0F39F41EB5C138A9381BEEDD73D3 /* HTTPResponseBody.swift */; };
+		F057F98A94728AA9DDBF299A76985100 /* SubscriptionPeriod.swift in Sources */ = {isa = PBXBuildFile; fileRef = 430B7A74CC7D58F29E38A9E253A6936C /* SubscriptionPeriod.swift */; };
+		F09CC0D2BD9F3695101190AEFE7F6EAF /* IntroEligibilityCalculator.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA38F44871620BD4FE0212F0B54879D1 /* IntroEligibilityCalculator.swift */; };
+		F0D42DBC32B9F86DEB9A7520D58536D7 /* SwiftVersionCheck.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5140E08D3EA6B021076F31151B61F5DB /* SwiftVersionCheck.swift */; };
+		F17EE585EC7215B65AA3C253176F1E38 /* BeginRefundRequestHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48E6993B79D76DCDFDCA7689A4ACC8B7 /* BeginRefundRequestHelper.swift */; };
+		F45ACF6F5FA286B857785DB0C86376B9 /* Configuration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67DA97684D19FD71B9EF56DF251D6E20 /* Configuration.swift */; };
+		F49301EF97E33765A6722A1B9E6280CC /* Storefront.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD2E2D1123673CA38A911895CAAB2313 /* Storefront.swift */; };
+		F55603F7D985B35A6B86B90129F5D883 /* FileReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 137AD66CF50C1F471559B1C457D0B9EE /* FileReader.swift */; };
+		F76D65BD86DF113105C93E5B578FE896 /* StoreKit2StorefrontListener.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30A7B6E022ADC514EDEEC4F09D1FB374 /* StoreKit2StorefrontListener.swift */; };
+		F7D76039F3734DA00065430ADC1CDA33 /* Pods-RevenueCatUIProxy-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 6012F2507EBBCBEB17C818C924F73339 /* Pods-RevenueCatUIProxy-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F7F501748E66F81D91D54E43FC6E6D44 /* StorefrontProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6F938E10F45AF0E92A5EFAF3E6BC733 /* StorefrontProvider.swift */; };
+		F7FEEC4CC2455EBE43E2A33675C6CE04 /* AttributionKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D8D1ADBCEA973D31C7B2D2C54027B26 /* AttributionKey.swift */; };
+		F9C2803C3DABA366642DAC9CDC01CCDA /* ReceiptParserLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55F9D886F2028AF4A70F1639A5F1B193 /* ReceiptParserLogger.swift */; };
+		FA888FE36CD82D3904196229996F4FCC /* AfficheClientProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9AF5E494796D1DEB53588A9EA7FC6DE /* AfficheClientProxy.swift */; };
+		FAD61972F6EF4E39CB13B85B70C03CEA /* CustomerInfo+ActiveDates.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97719782A8CF27506B99BF4DFD2C7B30 /* CustomerInfo+ActiveDates.swift */; };
+		FD274D5835582AB8066B112899DE3B24 /* EmptyFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BF147FC220F89E895718029DDA23718 /* EmptyFile.swift */; };
+		FDAED906C6B93A119EDA8BE6906BFC53 /* TransactionPoster.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAC29964EE7FD66D8328C25801C25C37 /* TransactionPoster.swift */; };
+		FE4BD2F82A436D4BAA7D09BFA461858A /* OfferingsAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE29ABC278A4DDFE424B7A9631081AE0 /* OfferingsAPI.swift */; };
+		FE4D2BCE661617CF42A73ED0CB774E0F /* RemoteImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BD9BCBBA86BC162F7E3B9F5FA3E3822 /* RemoteImage.swift */; };
+		FE545196EE3B9EFBD5B4447E237A3A9C /* NetworkError.swift in Sources */ = {isa = PBXBuildFile; fileRef = A562766731C71CF59A1FDFB9C15B669A /* NetworkError.swift */; };
+		FEE3B04C326C150FBA5A941BAFDCE326 /* HTTPRequest+Signing.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA2567ED3DCAD2FFE867DBC8DE74D90A /* HTTPRequest+Signing.swift */; };
+		FF24C816B3F03000D43278A0C4EC27CA /* FooterHidingModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3245B97509D7C05BD0B1EFA77CBB7624 /* FooterHidingModifier.swift */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		071D781B3E06A82768BCF2D6D5EBC819 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = CF57851EC915911B4B6C714AC16BCFFF;
+			remoteInfo = "RevenueCatUI-RevenueCat_RevenueCatUI";
+		};
+		C84FBE1890DFCD64ABBE7DA943115731 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = A9FD6F34305C03A1CC3A10B207522C48;
+			remoteInfo = RevenueCat;
+		};
+		D31E11CF1BE010DF9AF87CAF62652A68 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = A9FD6F34305C03A1CC3A10B207522C48;
+			remoteInfo = RevenueCat;
+		};
+		DB64E50BE9000E954994A667784A19F1 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = A57E526C97CEB07B0DAB27D9FC709692;
+			remoteInfo = RevenueCatUI;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXFileReference section */
+		0052237C8F47C201B87019F8E3B3D4E9 /* CustomerInfo+OfflineEntitlements.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "CustomerInfo+OfflineEntitlements.swift"; path = "Sources/OfflineEntitlements/CustomerInfo+OfflineEntitlements.swift"; sourceTree = "<group>"; };
+		0101944FD91EA7AD3C015C203B23C41D /* FakeSigning.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = FakeSigning.swift; path = Sources/Security/FakeSigning.swift; sourceTree = "<group>"; };
+		017BDCE2D2662FA6A493CF1BFB25B6A4 /* SynchronizedUserDefaults.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SynchronizedUserDefaults.swift; path = Sources/Misc/Concurrency/SynchronizedUserDefaults.swift; sourceTree = "<group>"; };
+		01C6E8CDE817B89AF6687351BB2E760A /* Purchases.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Purchases.swift; path = Sources/Purchasing/Purchases/Purchases.swift; sourceTree = "<group>"; };
+		026CA7DFD3D5AB3571B6EBC7ADB35A2A /* RevenueCatUI.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = RevenueCatUI.debug.xcconfig; sourceTree = "<group>"; };
+		034DECCA994D46B6BCED9C208E232D60 /* AsyncExtensions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AsyncExtensions.swift; path = Sources/FoundationExtensions/AsyncExtensions.swift; sourceTree = "<group>"; };
+		03A3FC674FBD50C2ACF0FCAF4A1715E4 /* SK1StoreProduct.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SK1StoreProduct.swift; path = Sources/Purchasing/StoreKitAbstractions/SK1StoreProduct.swift; sourceTree = "<group>"; };
+		0419E764195EDDC1046E8940A59B8985 /* ConfigureStrings.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ConfigureStrings.swift; path = Sources/Logging/Strings/ConfigureStrings.swift; sourceTree = "<group>"; };
+		049DE7D491B9ABFCDEB8331755E541C2 /* UserDefaults+Extensions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "UserDefaults+Extensions.swift"; path = "Sources/FoundationExtensions/UserDefaults+Extensions.swift"; sourceTree = "<group>"; };
+		04DC4F5D389AE04EEDF3898FF00F04DE /* Bundle+Extensions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Bundle+Extensions.swift"; path = "RevenueCatUI/Helpers/Bundle+Extensions.swift"; sourceTree = "<group>"; };
+		053471365AC83C6665EC2185F7C5DB6D /* HTTPResponse.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = HTTPResponse.swift; path = Sources/Networking/HTTPClient/HTTPResponse.swift; sourceTree = "<group>"; };
+		06E245E6676726EB6576F1AC42ED9278 /* Template4View.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Template4View.swift; path = RevenueCatUI/Templates/Template4View.swift; sourceTree = "<group>"; };
+		06E5399767DAD7EA0AADC5104A54C55B /* ErrorCode.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ErrorCode.swift; path = "Sources/Error Handling/ErrorCode.swift"; sourceTree = "<group>"; };
+		0B0C1CD9109C6C6934435F40D7566338 /* GetCustomerInfoOperation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = GetCustomerInfoOperation.swift; path = Sources/Networking/Operations/GetCustomerInfoOperation.swift; sourceTree = "<group>"; };
+		0B3E9FF33208A4C0837A100BCEBF6A8C /* Localizable.strings */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.strings; name = Localizable.strings; path = pt_BR.lproj/Localizable.strings; sourceTree = "<group>"; };
+		0BD9BCBBA86BC162F7E3B9F5FA3E3822 /* RemoteImage.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = RemoteImage.swift; path = RevenueCatUI/Views/RemoteImage.swift; sourceTree = "<group>"; };
+		0BF147FC220F89E895718029DDA23718 /* EmptyFile.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = EmptyFile.swift; path = Sources/DocCDocumentation/EmptyFile.swift; sourceTree = "<group>"; };
+		0C18DEAA6661BFE23A38B1CB3BFB940A /* ETagStrings.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ETagStrings.swift; path = Sources/Logging/Strings/ETagStrings.swift; sourceTree = "<group>"; };
+		0C892F5517EDE2CCE92333D5214BF6C9 /* SubscriberAttributesManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SubscriberAttributesManager.swift; path = Sources/SubscriberAttributes/SubscriberAttributesManager.swift; sourceTree = "<group>"; };
+		0D5274C800BC3283A9BCF045ABAB89E9 /* NonEmptyStringDecodable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = NonEmptyStringDecodable.swift; path = Sources/Misc/Codable/NonEmptyStringDecodable.swift; sourceTree = "<group>"; };
+		0D9EF3D22D8759B4F58CD80511161030 /* CustomerInfoResponseHandler.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CustomerInfoResponseHandler.swift; path = Sources/Networking/Operations/Handling/CustomerInfoResponseHandler.swift; sourceTree = "<group>"; };
+		0E454A81509B8947AC746BB2DACF1D90 /* Decoder+Extensions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Decoder+Extensions.swift"; path = "Sources/FoundationExtensions/Decoder+Extensions.swift"; sourceTree = "<group>"; };
+		0F3323B15F06428E6B106BCCC35F99DF /* TemplateViewType.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = TemplateViewType.swift; path = RevenueCatUI/Templates/TemplateViewType.swift; sourceTree = "<group>"; };
+		0F8A9C1F4DF9F62BD23CFF55676028E1 /* EligibilityStrings.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = EligibilityStrings.swift; path = Sources/Logging/Strings/EligibilityStrings.swift; sourceTree = "<group>"; };
+		1015E76DED97C427C4AC84304ABD8B99 /* GetProductEntitlementMappingOperation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = GetProductEntitlementMappingOperation.swift; path = Sources/Networking/Operations/GetProductEntitlementMappingOperation.swift; sourceTree = "<group>"; };
+		117C91FD3ABC917953962A303F46588A /* Logger.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Logger.swift; path = Sources/Logging/Logger.swift; sourceTree = "<group>"; };
+		12B490CCDAAAC6E5C8FD853D3A7B1049 /* Purchases+async.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Purchases+async.swift"; path = "Sources/Misc/Concurrency/Purchases+async.swift"; sourceTree = "<group>"; };
+		137AD66CF50C1F471559B1C457D0B9EE /* FileReader.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = FileReader.swift; path = Sources/LocalReceiptParsing/Helpers/FileReader.swift; sourceTree = "<group>"; };
+		13B0CB406CF2B1448F56735252C8D71C /* DescribableError.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DescribableError.swift; path = "Sources/Error Handling/DescribableError.swift"; sourceTree = "<group>"; };
+		13F73941C6E2F9A432BDD964F8D635E5 /* VerificationResult.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = VerificationResult.swift; path = Sources/Security/VerificationResult.swift; sourceTree = "<group>"; };
+		14A5ACBE79C0A9EF7DE745D39FE974A0 /* Error+Extensions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Error+Extensions.swift"; path = "Sources/FoundationExtensions/Error+Extensions.swift"; sourceTree = "<group>"; };
+		14B426F1B92DD2C66583E6C29D7B01B4 /* PaywallData.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PaywallData.swift; path = Sources/Paywalls/PaywallData.swift; sourceTree = "<group>"; };
+		14B910F48D4FA0696034A567169B3A67 /* Localizable.strings */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.strings; name = Localizable.strings; path = zh_Hans.lproj/Localizable.strings; sourceTree = "<group>"; };
+		14E41114011B836BCA97F57D33AB71C0 /* Localizable.strings */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.strings; name = Localizable.strings; path = ru.lproj/Localizable.strings; sourceTree = "<group>"; };
+		1628C9B7F9C3B39A0EE2661659144691 /* DebugViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DebugViewController.swift; path = Sources/Support/DebugUI/DebugViewController.swift; sourceTree = "<group>"; };
+		1765ADD1D0C7468CC4CC8B7EA3E1FD09 /* OfflineCustomerInfoCreator.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = OfflineCustomerInfoCreator.swift; path = Sources/OfflineEntitlements/OfflineCustomerInfoCreator.swift; sourceTree = "<group>"; };
+		178AA9CFB3106D2B67393570C1724C6B /* ReceiptFetcher.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ReceiptFetcher.swift; path = Sources/Purchasing/ReceiptFetcher.swift; sourceTree = "<group>"; };
+		186B06A2048E16FB31CD76A67AF29159 /* Pods-RevenueCatUIProxy.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-RevenueCatUIProxy.release.xcconfig"; sourceTree = "<group>"; };
+		1A267014AAE8F350958902647265514C /* SandboxEnvironmentDetector.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SandboxEnvironmentDetector.swift; path = Sources/Misc/SandboxEnvironmentDetector.swift; sourceTree = "<group>"; };
+		1A598E5E0F263DBE91FD61575F46786F /* AttributionFetcher.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AttributionFetcher.swift; path = Sources/Attribution/AttributionFetcher.swift; sourceTree = "<group>"; };
+		1AF82E31C65331D8A1A6CD1B3D40CB50 /* StoreEnvironment.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = StoreEnvironment.swift; path = Sources/Purchasing/StoreKitAbstractions/StoreEnvironment.swift; sourceTree = "<group>"; };
+		1B6A4EABEDDA29B13EA2006FBDF9F895 /* TransactionsManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = TransactionsManager.swift; path = Sources/Purchasing/TransactionsManager.swift; sourceTree = "<group>"; };
+		1C0848DD5307985FCBF2D148277E556E /* PurchasesDiagnostics.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PurchasesDiagnostics.swift; path = Sources/Support/PurchasesDiagnostics.swift; sourceTree = "<group>"; };
+		1C2554ECF1D573B9C52E9F96796B9A0E /* Dictionary+Extensions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Dictionary+Extensions.swift"; path = "Sources/FoundationExtensions/Dictionary+Extensions.swift"; sourceTree = "<group>"; };
+		1D12C677933E69762F563CAF9D81A475 /* String+Extensions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "String+Extensions.swift"; path = "Sources/FoundationExtensions/String+Extensions.swift"; sourceTree = "<group>"; };
+		1D6C1E088788A6FB0072DC9428290C99 /* RevenueCatUI-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "RevenueCatUI-prefix.pch"; sourceTree = "<group>"; };
+		1D773688C1E38F7BD47217D67B401202 /* ISOPeriodFormatter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ISOPeriodFormatter.swift; path = Sources/Misc/DateAndTime/ISOPeriodFormatter.swift; sourceTree = "<group>"; };
+		1D82FDC22586B0B4387FCCB4BFB50CD4 /* PurchasesDelegate.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PurchasesDelegate.swift; path = Sources/Purchasing/Purchases/PurchasesDelegate.swift; sourceTree = "<group>"; };
+		1D8D1ADBCEA973D31C7B2D2C54027B26 /* AttributionKey.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AttributionKey.swift; path = Sources/SubscriberAttributes/AttributionKey.swift; sourceTree = "<group>"; };
+		1DA580A1B0CBCF823287724ADB279BCF /* Localizable.strings */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.strings; name = Localizable.strings; path = it.lproj/Localizable.strings; sourceTree = "<group>"; };
+		1E20C245A924BD3C35AB64A1D16C417B /* PaywallStoredEvent.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PaywallStoredEvent.swift; path = Sources/Paywalls/Events/PaywallStoredEvent.swift; sourceTree = "<group>"; };
+		1EE9CBD6F97E39B55366105608A72B9B /* SK2Storefront.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SK2Storefront.swift; path = Sources/Purchasing/StoreKitAbstractions/SK2Storefront.swift; sourceTree = "<group>"; };
+		1F7240EE6A5EFE74509BD484A0588DF4 /* DebugErrorView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DebugErrorView.swift; path = RevenueCatUI/Views/DebugErrorView.swift; sourceTree = "<group>"; };
+		20ACED2DAF329A74B31102084342FB10 /* PurchasesOrchestrator.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PurchasesOrchestrator.swift; path = Sources/Purchasing/Purchases/PurchasesOrchestrator.swift; sourceTree = "<group>"; };
+		20CD4570AC2ADC5319078D71EA671872 /* Localizable.strings */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.strings; name = Localizable.strings; path = en_AU.lproj/Localizable.strings; sourceTree = "<group>"; };
+		2145099333FBAEEB8A7DD4BC2ADB176F /* Template2View.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Template2View.swift; path = RevenueCatUI/Templates/Template2View.swift; sourceTree = "<group>"; };
+		21C1E1098345081ABAF01BA2A8E876FB /* AttributionNetwork.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AttributionNetwork.swift; path = Sources/Attribution/AttributionNetwork.swift; sourceTree = "<group>"; };
+		2204801CE2EC17213FD239AE398508E4 /* TrackingManagerProxy.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = TrackingManagerProxy.swift; path = Sources/Attribution/TrackingManagerProxy.swift; sourceTree = "<group>"; };
+		222131C342DD6835365FA5048A996250 /* DefaultDecodable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DefaultDecodable.swift; path = Sources/Misc/Codable/DefaultDecodable.swift; sourceTree = "<group>"; };
+		2308FBF7951C8C0A9766F5B0041B96CD /* ProductEntitlementMappingCallback.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ProductEntitlementMappingCallback.swift; path = Sources/Networking/Caching/ProductEntitlementMappingCallback.swift; sourceTree = "<group>"; };
+		237F87F13D4BD6EF1C8B0AC49A8E9370 /* StoreProductDiscount.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = StoreProductDiscount.swift; path = Sources/Purchasing/StoreKitAbstractions/StoreProductDiscount.swift; sourceTree = "<group>"; };
+		23CEF064C5B5ABF69F1ABBA1ACE5B1AA /* FooterView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = FooterView.swift; path = RevenueCatUI/Views/FooterView.swift; sourceTree = "<group>"; };
+		23D8FDF2B1102058AAC884CE43EDA0D0 /* PurchaseOwnershipType.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PurchaseOwnershipType.swift; path = Sources/Purchasing/PurchaseOwnershipType.swift; sourceTree = "<group>"; };
+		25CBF776E957DAA2944AC2FE58157502 /* Template3View.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Template3View.swift; path = RevenueCatUI/Templates/Template3View.swift; sourceTree = "<group>"; };
+		25FA20A35B1C18890DA652125D391EAF /* IdentityStrings.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = IdentityStrings.swift; path = Sources/Logging/Strings/IdentityStrings.swift; sourceTree = "<group>"; };
+		2A06C922790FDFE1B4BD74209DB5E11B /* PromotionalOffer.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PromotionalOffer.swift; path = Sources/Purchasing/StoreKitAbstractions/PromotionalOffer.swift; sourceTree = "<group>"; };
+		2A14D5B64519109F3593E787ED24ACCE /* ProductType.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ProductType.swift; path = Sources/Purchasing/StoreKitAbstractions/ProductType.swift; sourceTree = "<group>"; };
+		2A4E0B1ED911611F228210AAB8F55782 /* PackageType.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PackageType.swift; path = Sources/Purchasing/PackageType.swift; sourceTree = "<group>"; };
+		2A76F609D62210D2D831C8EA3D519207 /* Localizable.strings */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.strings; name = Localizable.strings; path = nl.lproj/Localizable.strings; sourceTree = "<group>"; };
+		2B7394E4FA5715231A66BECB05871209 /* ErrorUtils.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ErrorUtils.swift; path = "Sources/Error Handling/ErrorUtils.swift"; sourceTree = "<group>"; };
+		2C0E330B41826951A072A6A252EE374D /* ProductsManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ProductsManager.swift; path = Sources/Purchasing/ProductsManager.swift; sourceTree = "<group>"; };
+		2CA9CE285EAB9403D4FA61784F244DD6 /* CodableStrings.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CodableStrings.swift; path = Sources/Logging/Strings/CodableStrings.swift; sourceTree = "<group>"; };
+		2CAF63F71AE6CF8C74E21584DBE6DF89 /* StoreMessagesHelper.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = StoreMessagesHelper.swift; path = Sources/Support/StoreMessagesHelper.swift; sourceTree = "<group>"; };
+		2D0D558FED95668F69D2BDAC461E7337 /* PaywallData+Default.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "PaywallData+Default.swift"; path = "RevenueCatUI/Helpers/PaywallData+Default.swift"; sourceTree = "<group>"; };
+		2D9E714CB697615148A5906730122F42 /* ManageSubscriptionsHelper.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ManageSubscriptionsHelper.swift; path = Sources/Support/ManageSubscriptionsHelper.swift; sourceTree = "<group>"; };
+		2E54795119F90AFB6D67DCC19F3D83B4 /* DebugViewModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DebugViewModel.swift; path = Sources/Support/DebugUI/DebugViewModel.swift; sourceTree = "<group>"; };
+		2E6DCB7DC4901FD63CCDDAE222A20EF7 /* ReceiptRefreshPolicy.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ReceiptRefreshPolicy.swift; path = Sources/Purchasing/ReceiptRefreshPolicy.swift; sourceTree = "<group>"; };
+		2E99153681E0D8F6D4C642F824A866F9 /* StoreTransaction.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = StoreTransaction.swift; path = Sources/Purchasing/StoreKitAbstractions/StoreTransaction.swift; sourceTree = "<group>"; };
+		2E9AFF147D2310B1DE529DBBA90B216B /* EncodedAppleReceipt.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = EncodedAppleReceipt.swift; path = Sources/Purchasing/StoreKitAbstractions/EncodedAppleReceipt.swift; sourceTree = "<group>"; };
+		2FE85C9B0C62CB2237635DFC367C935E /* DateProvider.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DateProvider.swift; path = Sources/Misc/DateAndTime/DateProvider.swift; sourceTree = "<group>"; };
+		30A7B6E022ADC514EDEEC4F09D1FB374 /* StoreKit2StorefrontListener.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = StoreKit2StorefrontListener.swift; path = Sources/Purchasing/StoreKit2/StoreKit2StorefrontListener.swift; sourceTree = "<group>"; };
+		30DF6F969560A7C4881C71B84720218F /* Assertions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Assertions.swift; path = "Sources/Error Handling/Assertions.swift"; sourceTree = "<group>"; };
+		31816E7AF5B16DE42937CD24ED83E20D /* PaywallCacheWarming.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PaywallCacheWarming.swift; path = Sources/Paywalls/PaywallCacheWarming.swift; sourceTree = "<group>"; };
+		3245B97509D7C05BD0B1EFA77CBB7624 /* FooterHidingModifier.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = FooterHidingModifier.swift; path = RevenueCatUI/Modifiers/FooterHidingModifier.swift; sourceTree = "<group>"; };
+		32F5E6BC7E0B3F3B80716DF65F718732 /* GetIntroEligibilityOperation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = GetIntroEligibilityOperation.swift; path = Sources/Networking/Operations/GetIntroEligibilityOperation.swift; sourceTree = "<group>"; };
+		3333D851B66855FCC88037DA067972F5 /* OperationQueue+Extensions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "OperationQueue+Extensions.swift"; path = "Sources/FoundationExtensions/OperationQueue+Extensions.swift"; sourceTree = "<group>"; };
+		334E024B920045978835E0253D39407D /* SK2BeginRefundRequestHelper.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SK2BeginRefundRequestHelper.swift; path = Sources/Purchasing/StoreKit2/SK2BeginRefundRequestHelper.swift; sourceTree = "<group>"; };
+		34034DAE3C091E4478F25FCD36D74A3E /* PreviewHelpers.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PreviewHelpers.swift; path = RevenueCatUI/Helpers/PreviewHelpers.swift; sourceTree = "<group>"; };
+		357F0C3821C69EA9072751220A9E4CFC /* RevenueCatUI */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = RevenueCatUI; path = RevenueCatUI.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		3597BF99FB7D38A634D97D665FBFE1A0 /* PurchaseHandler+TestData.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "PurchaseHandler+TestData.swift"; path = "RevenueCatUI/Purchasing/PurchaseHandler+TestData.swift"; sourceTree = "<group>"; };
+		36B9946F0EB0253FF8CB6EDCBA3253A6 /* ViewExtensions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ViewExtensions.swift; path = RevenueCatUI/Modifiers/ViewExtensions.swift; sourceTree = "<group>"; };
+		372EE7ABE674EA19272F3A4F0FC6DDF3 /* Offering.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Offering.swift; path = Sources/Purchasing/Offering.swift; sourceTree = "<group>"; };
+		37A59D4BA7C39F3C2CFB7178B3FC4CE7 /* ProgressView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ProgressView.swift; path = RevenueCatUI/Views/ProgressView.swift; sourceTree = "<group>"; };
+		3858205357F8B2DDA9C988D7AABA7489 /* PaywallHTTPRequestPath.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PaywallHTTPRequestPath.swift; path = Sources/Paywalls/Events/Networking/PaywallHTTPRequestPath.swift; sourceTree = "<group>"; };
+		38A77254A36685B116565ACACF9116A2 /* StoreKit1Wrapper.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = StoreKit1Wrapper.swift; path = Sources/Purchasing/StoreKit1/StoreKit1Wrapper.swift; sourceTree = "<group>"; };
+		38F35B773B19A40746F29FFAEB665FCA /* Localizable.strings */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.strings; name = Localizable.strings; path = cs.lproj/Localizable.strings; sourceTree = "<group>"; };
+		3C00696A7C38211D433C22DC147D2264 /* StoreKit2TransactionFetcher.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = StoreKit2TransactionFetcher.swift; path = Sources/Purchasing/StoreKit2/StoreKit2TransactionFetcher.swift; sourceTree = "<group>"; };
+		3C17E266D5A3121C791A3F4D7D01C54D /* ProductRequestData.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ProductRequestData.swift; path = Sources/Purchasing/ProductRequestData.swift; sourceTree = "<group>"; };
+		3CCCBD19E9BD2D38AD333A3AD5328EC4 /* PaywallsStrings.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PaywallsStrings.swift; path = Sources/Logging/Strings/PaywallsStrings.swift; sourceTree = "<group>"; };
+		3CD58377164B1105465F5DACD097B975 /* PostOfferForSigningOperation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PostOfferForSigningOperation.swift; path = Sources/Networking/Operations/PostOfferForSigningOperation.swift; sourceTree = "<group>"; };
+		3CE96248BEF99DDC1E7850CB57FDDEB0 /* SK2StoreProduct.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SK2StoreProduct.swift; path = Sources/Purchasing/StoreKitAbstractions/SK2StoreProduct.swift; sourceTree = "<group>"; };
+		3D4BD6CCCEE68209D38D974AC89C2FE3 /* AttributionDataMigrator.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AttributionDataMigrator.swift; path = Sources/SubscriberAttributes/AttributionDataMigrator.swift; sourceTree = "<group>"; };
+		3DE57DB635EA829EBEDA10D7FBB436F8 /* IgnoreHashable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = IgnoreHashable.swift; path = Sources/Misc/Codable/IgnoreHashable.swift; sourceTree = "<group>"; };
+		3F1BFCA3528D7022573FF89003AA31BA /* View+PresentPaywallFooter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "View+PresentPaywallFooter.swift"; path = "RevenueCatUI/View+PresentPaywallFooter.swift"; sourceTree = "<group>"; };
+		4039D362E6B5E36F2FA9A4571C5451F3 /* RevenueCatUI.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = RevenueCatUI.release.xcconfig; sourceTree = "<group>"; };
+		40AE340C6D312EAEAA74A3262E66DB53 /* HTTPRequestBody+Signing.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "HTTPRequestBody+Signing.swift"; path = "Sources/Security/HTTPRequestBody+Signing.swift"; sourceTree = "<group>"; };
+		41C9477D371661E8E7C3BF93A1434D74 /* PaywallTemplate.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PaywallTemplate.swift; path = RevenueCatUI/Data/PaywallTemplate.swift; sourceTree = "<group>"; };
+		42470306638B63A79F5841EE989E46F9 /* TrialOrIntroEligibilityChecker.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = TrialOrIntroEligibilityChecker.swift; path = RevenueCatUI/Data/IntroEligibility/TrialOrIntroEligibilityChecker.swift; sourceTree = "<group>"; };
+		424C4326E46065FCEC6CD8779751DFC5 /* RevenueCatUI-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "RevenueCatUI-Info.plist"; sourceTree = "<group>"; };
+		430B7A74CC7D58F29E38A9E253A6936C /* SubscriptionPeriod.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SubscriptionPeriod.swift; path = Sources/Purchasing/StoreKitAbstractions/SubscriptionPeriod.swift; sourceTree = "<group>"; };
+		43B64DF06A7ED3B998E74B51AF14BAFC /* Deprecations.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Deprecations.swift; path = Sources/Misc/Deprecations.swift; sourceTree = "<group>"; };
+		440FFCAC3E64221C41EB1DBD4E6FE40B /* Localizable.strings */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.strings; name = Localizable.strings; path = ca.lproj/Localizable.strings; sourceTree = "<group>"; };
+		447660A1325B3D6BA209156F274EB920 /* PaywallError.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PaywallError.swift; path = RevenueCatUI/Data/Errors/PaywallError.swift; sourceTree = "<group>"; };
+		44A9FA068FE7DBF0A30AD0985845010E /* DeviceCache.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DeviceCache.swift; path = Sources/Caching/DeviceCache.swift; sourceTree = "<group>"; };
+		4560C1E5ED8F09031BE6D4B5B5CDF727 /* DiagnosticsStrings.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DiagnosticsStrings.swift; path = Sources/Logging/Strings/DiagnosticsStrings.swift; sourceTree = "<group>"; };
+		457785D495E608B772FF2A41CF66CDED /* StoreKit2TransactionListener.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = StoreKit2TransactionListener.swift; path = Sources/Purchasing/StoreKit2/StoreKit2TransactionListener.swift; sourceTree = "<group>"; };
+		45B01B021164958A1A1625CE10CD6777 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS14.0.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
+		4632275F8ECBCABA3EF959CB510B50A6 /* SK1Storefront.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SK1Storefront.swift; path = Sources/Purchasing/StoreKitAbstractions/SK1Storefront.swift; sourceTree = "<group>"; };
+		4655E6676D387C53933381D2DA91A18D /* Pods-RevenueCatUIProxy-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-RevenueCatUIProxy-acknowledgements.markdown"; sourceTree = "<group>"; };
+		46B538D4275ACB6D2A16D4ECFE619F44 /* AttributionData.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AttributionData.swift; path = Sources/Attribution/AttributionData.swift; sourceTree = "<group>"; };
+		47FDB7A0628B5B9951743BBF97ABCC7A /* PaywallEventSerializer.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PaywallEventSerializer.swift; path = Sources/Paywalls/Events/PaywallEventSerializer.swift; sourceTree = "<group>"; };
+		4837F9FEC3E3C7809E628FBCA94EEF67 /* PaywallEvent.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PaywallEvent.swift; path = Sources/Paywalls/Events/PaywallEvent.swift; sourceTree = "<group>"; };
+		485D3A527946E757618BEC7D14F65D2E /* Obsoletions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Obsoletions.swift; path = Sources/Misc/Obsoletions.swift; sourceTree = "<group>"; };
+		48E6993B79D76DCDFDCA7689A4ACC8B7 /* BeginRefundRequestHelper.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BeginRefundRequestHelper.swift; path = Sources/Support/BeginRefundRequestHelper.swift; sourceTree = "<group>"; };
+		4922199D5683E03888AE7BCFADB60703 /* CallbackCache.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CallbackCache.swift; path = Sources/Networking/Caching/CallbackCache.swift; sourceTree = "<group>"; };
+		4949EA4DC67310D8339EFF214B672911 /* VersionDetector.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = VersionDetector.swift; path = RevenueCatUI/Helpers/VersionDetector.swift; sourceTree = "<group>"; };
+		49DD941877FDE851657A51E48AD31B65 /* View+PurchaseRestoreCompleted.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "View+PurchaseRestoreCompleted.swift"; path = "RevenueCatUI/View+PurchaseRestoreCompleted.swift"; sourceTree = "<group>"; };
+		4A33F17DC912774CC470B3C97C4F20D7 /* Localizable.strings */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.strings; name = Localizable.strings; path = id.lproj/Localizable.strings; sourceTree = "<group>"; };
+		4C287E21017EBC7041BEB0F82ECF89B0 /* Pods-RevenueCatUIProxy.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-RevenueCatUIProxy.debug.xcconfig"; sourceTree = "<group>"; };
+		4DCF45CE4D6986498F68051BF600585B /* Locale+Extensions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Locale+Extensions.swift"; path = "Sources/FoundationExtensions/Locale+Extensions.swift"; sourceTree = "<group>"; };
+		4E2C1AF69886A1A3A2F3591D6882C795 /* Localizable.strings */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.strings; name = Localizable.strings; path = sv.lproj/Localizable.strings; sourceTree = "<group>"; };
+		4E8EEFF0916467A473EDC2705419D8AC /* Set+Extensions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Set+Extensions.swift"; path = "Sources/FoundationExtensions/Set+Extensions.swift"; sourceTree = "<group>"; };
+		4EDBF31628D5E3EB2E2815F9A40BAD4A /* Template1View.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Template1View.swift; path = RevenueCatUI/Templates/Template1View.swift; sourceTree = "<group>"; };
+		4F151C45B517CDAF823A8E8FCC2339DD /* ProductEntitlementMappingFetcher.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ProductEntitlementMappingFetcher.swift; path = Sources/OfflineEntitlements/ProductEntitlementMappingFetcher.swift; sourceTree = "<group>"; };
+		506856395E0C6776C54614F07BD6C60F /* PostOfferResponse.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PostOfferResponse.swift; path = Sources/Networking/Responses/PostOfferResponse.swift; sourceTree = "<group>"; };
+		50897242FE3F0350B560DCCFB297160E /* Localizable.strings */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.strings; name = Localizable.strings; path = kk.lproj/Localizable.strings; sourceTree = "<group>"; };
+		50D224502BBCC9632B3FA00E5A20D6C0 /* Pods-RevenueCatUIProxy.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = "Pods-RevenueCatUIProxy.modulemap"; sourceTree = "<group>"; };
+		5140E08D3EA6B021076F31151B61F5DB /* SwiftVersionCheck.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SwiftVersionCheck.swift; path = Sources/Support/SwiftVersionCheck.swift; sourceTree = "<group>"; };
+		5184776B9AC1C9A7DA509C2297014A09 /* StoreKit2Setting.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = StoreKit2Setting.swift; path = Sources/Misc/StoreKit2Setting.swift; sourceTree = "<group>"; };
+		5268F6651D7ECE855E7A42C8C4EC7C99 /* ProductEntitlementMappingResponse.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ProductEntitlementMappingResponse.swift; path = Sources/Networking/Responses/ProductEntitlementMappingResponse.swift; sourceTree = "<group>"; };
+		53E24F8FE1375A9E933203DFC5C06759 /* Integer+Extensions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Integer+Extensions.swift"; path = "Sources/FoundationExtensions/Integer+Extensions.swift"; sourceTree = "<group>"; };
+		543820EA7B80A86AD898134AB2470C15 /* Localizable.strings */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.strings; name = Localizable.strings; path = ar.lproj/Localizable.strings; sourceTree = "<group>"; };
+		5448EFDDD99FB7B52C918ED932A253F6 /* ASN1ContainerBuilder.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ASN1ContainerBuilder.swift; path = Sources/LocalReceiptParsing/Builders/ASN1ContainerBuilder.swift; sourceTree = "<group>"; };
+		55A776A74CE9ADEC37DA5F29D75DA961 /* UInt8+Extensions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "UInt8+Extensions.swift"; path = "Sources/LocalReceiptParsing/DataConverters/UInt8+Extensions.swift"; sourceTree = "<group>"; };
+		55F9D886F2028AF4A70F1639A5F1B193 /* ReceiptParserLogger.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ReceiptParserLogger.swift; path = Sources/LocalReceiptParsing/Helpers/ReceiptParserLogger.swift; sourceTree = "<group>"; };
+		57B6CCD71E676992D5ECB28F332BD186 /* Localizable.strings */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.strings; name = Localizable.strings; path = hu.lproj/Localizable.strings; sourceTree = "<group>"; };
+		5830B063A00F011FD05D7453D10BF423 /* MockPurchases.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = MockPurchases.swift; path = RevenueCatUI/Purchasing/MockPurchases.swift; sourceTree = "<group>"; };
+		585C576BCECE23BC51069949ED78CBED /* GetIntroEligibilityResponse.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = GetIntroEligibilityResponse.swift; path = Sources/Networking/Responses/GetIntroEligibilityResponse.swift; sourceTree = "<group>"; };
+		58F7BCD9188AFAED6E5B54753313FFAF /* TestStoreProductDiscount.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = TestStoreProductDiscount.swift; path = "Sources/Purchasing/StoreKitAbstractions/Test Data/TestStoreProductDiscount.swift"; sourceTree = "<group>"; };
+		5AF51E27768FD1642CFC3162DA97AB6B /* BackendErrorCode.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BackendErrorCode.swift; path = "Sources/Error Handling/BackendErrorCode.swift"; sourceTree = "<group>"; };
+		5E3B60AAB45031386B36873ADBF71D52 /* Optional+Extensions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Optional+Extensions.swift"; path = "RevenueCatUI/Helpers/Optional+Extensions.swift"; sourceTree = "<group>"; };
+		5E48A52143B096EFAC48DF76EB9AB992 /* PackageButtonStyle.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PackageButtonStyle.swift; path = RevenueCatUI/Views/PackageButtonStyle.swift; sourceTree = "<group>"; };
+		5EE436FCBE03A50CFE0BFDED3248991D /* PaywallViewMode+Extensions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "PaywallViewMode+Extensions.swift"; path = "RevenueCatUI/Data/PaywallViewMode+Extensions.swift"; sourceTree = "<group>"; };
+		5EF63ABD9CCDBA84E50E3E8EC01DE837 /* FrameworkDisambiguation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = FrameworkDisambiguation.swift; path = Sources/Support/FrameworkDisambiguation.swift; sourceTree = "<group>"; };
+		5F4775BD35B655C01C21D38D0C99A400 /* DebugView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DebugView.swift; path = Sources/Support/DebugUI/DebugView.swift; sourceTree = "<group>"; };
+		5FDEBCE68D047156CC4491F401F822C0 /* AttributionStrings.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AttributionStrings.swift; path = Sources/Logging/Strings/AttributionStrings.swift; sourceTree = "<group>"; };
+		5FF4B2CCBE3A9020A6F6BE3EF4A4EE0E /* SK1StoreProductDiscount.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SK1StoreProductDiscount.swift; path = Sources/Purchasing/StoreKitAbstractions/SK1StoreProductDiscount.swift; sourceTree = "<group>"; };
+		6012F2507EBBCBEB17C818C924F73339 /* Pods-RevenueCatUIProxy-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-RevenueCatUIProxy-umbrella.h"; sourceTree = "<group>"; };
+		6033FA7AF38C1F87F0BB91E10EEACBD2 /* Box.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Box.swift; path = Sources/Misc/Box.swift; sourceTree = "<group>"; };
+		605FAED5A8B4D8E8444DE897D121B3BC /* SK2StoreProductDiscount.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SK2StoreProductDiscount.swift; path = Sources/Purchasing/StoreKitAbstractions/SK2StoreProductDiscount.swift; sourceTree = "<group>"; };
+		61CF97E5EE29C235E2D75FBFC1389782 /* LogInOperation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = LogInOperation.swift; path = Sources/Networking/Operations/LogInOperation.swift; sourceTree = "<group>"; };
+		621B0F39F41EB5C138A9381BEEDD73D3 /* HTTPResponseBody.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = HTTPResponseBody.swift; path = Sources/Networking/HTTPClient/HTTPResponseBody.swift; sourceTree = "<group>"; };
+		62C9C421792A5E274CBF3F9836C6C83C /* Localizable.strings */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.strings; name = Localizable.strings; path = hr.lproj/Localizable.strings; sourceTree = "<group>"; };
+		6313B707C269CB3C69585C430AACD82C /* RevenueCat.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = RevenueCat.release.xcconfig; sourceTree = "<group>"; };
+		6321ABC8B416568CCD2ABFFE29455F67 /* OfferingsCallback.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = OfferingsCallback.swift; path = Sources/Networking/Caching/OfferingsCallback.swift; sourceTree = "<group>"; };
+		6569112F41AB17C8594AA45D46F8A643 /* WatchTemplateView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = WatchTemplateView.swift; path = "RevenueCatUI/Templates/Other platforms/WatchTemplateView.swift"; sourceTree = "<group>"; };
+		65D5E2CD27BF5A77B217D577012536C6 /* UserInterfaceIdiom.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = UserInterfaceIdiom.swift; path = RevenueCatUI/Data/UserInterfaceIdiom.swift; sourceTree = "<group>"; };
+		65DEE76C6E51125654D7BE7EA5B0ED63 /* Localizable.strings */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.strings; name = Localizable.strings; path = tr.lproj/Localizable.strings; sourceTree = "<group>"; };
+		65F8FB72680A164D17E715E2D9BA11A7 /* SystemInfo.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SystemInfo.swift; path = Sources/Misc/SystemInfo.swift; sourceTree = "<group>"; };
+		6615C5A368D81A525045230D4EEF894F /* ASN1ObjectIdentifierBuilder.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ASN1ObjectIdentifierBuilder.swift; path = Sources/LocalReceiptParsing/Builders/ASN1ObjectIdentifierBuilder.swift; sourceTree = "<group>"; };
+		66710A8DB807A32CCF920B02C1218D22 /* StoreKit2Receipt.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = StoreKit2Receipt.swift; path = Sources/Purchasing/StoreKit2/StoreKit2Receipt.swift; sourceTree = "<group>"; };
+		6684D4C6BC54402CB322B27DBFC2F379 /* PurchaseStrings.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PurchaseStrings.swift; path = Sources/Logging/Strings/PurchaseStrings.swift; sourceTree = "<group>"; };
+		6702401664EC1391F906C9451C19B780 /* Localization.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Localization.swift; path = RevenueCatUI/Data/Localization.swift; sourceTree = "<group>"; };
+		674F47EFB90EAACA6A5717B6E77532C0 /* PostPaywallEventsOperation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PostPaywallEventsOperation.swift; path = Sources/Paywalls/Events/Networking/PostPaywallEventsOperation.swift; sourceTree = "<group>"; };
+		67DA97684D19FD71B9EF56DF251D6E20 /* Configuration.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Configuration.swift; path = Sources/Purchasing/Configuration.swift; sourceTree = "<group>"; };
+		6843F70FDDD5F5EA8EB0C7BFE1393CA2 /* Either.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Either.swift; path = Sources/Misc/Either.swift; sourceTree = "<group>"; };
+		68518B3344CC25984CAFD8D47D65FE6B /* Result+Extensions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Result+Extensions.swift"; path = "Sources/FoundationExtensions/Result+Extensions.swift"; sourceTree = "<group>"; };
+		689F831F8BE8C1B1C6C08CC4223E7C0B /* LoggerType.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = LoggerType.swift; path = Sources/LocalReceiptParsing/Helpers/LoggerType.swift; sourceTree = "<group>"; };
+		6A8E7C9C32D49E2DAC904653C469E28F /* RevenueCatUI.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = RevenueCatUI.modulemap; sourceTree = "<group>"; };
+		6AC17DB80457EE71A6F77CD47E80A6CC /* View+PresentPaywall.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "View+PresentPaywall.swift"; path = "RevenueCatUI/View+PresentPaywall.swift"; sourceTree = "<group>"; };
+		6C07E7D145AD32E7B349F50196E9D472 /* InMemoryCachedObject.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = InMemoryCachedObject.swift; path = Sources/Caching/InMemoryCachedObject.swift; sourceTree = "<group>"; };
+		6C632E78406DB8D85F72A8B774394728 /* Strings.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Strings.swift; path = RevenueCatUI/Data/Strings.swift; sourceTree = "<group>"; };
+		6D7021A1B5D6CC4892057D59033AEB68 /* DebugViewSheetPresentation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DebugViewSheetPresentation.swift; path = Sources/Support/DebugUI/DebugViewSheetPresentation.swift; sourceTree = "<group>"; };
+		6DFAD98DACDD279298644691491B9F6A /* RevenueCat.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = RevenueCat.debug.xcconfig; sourceTree = "<group>"; };
+		6E2CAC070D3FD34A0B997D67849A9651 /* AsyncButton.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AsyncButton.swift; path = RevenueCatUI/Views/AsyncButton.swift; sourceTree = "<group>"; };
+		6F4969D08ABA73D221FE57019A14CDE6 /* background.jpg */ = {isa = PBXFileReference; includeInIndex = 1; name = background.jpg; path = RevenueCatUI/Resources/background.jpg; sourceTree = "<group>"; };
+		6FC6E947C9DCB3A884F01458FF9460F1 /* Pods-RevenueCatUIProxy-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-RevenueCatUIProxy-acknowledgements.plist"; sourceTree = "<group>"; };
+		700B7847A5AAA7AF5105CD1019B84002 /* SK2AppTransaction.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SK2AppTransaction.swift; path = Sources/Purchasing/StoreKit2/SK2AppTransaction.swift; sourceTree = "<group>"; };
+		7142C9AD45DFD689443A103A599A3693 /* CallbackCacheStatus.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CallbackCacheStatus.swift; path = Sources/Networking/Caching/CallbackCacheStatus.swift; sourceTree = "<group>"; };
+		715411EDCA987814596E51D5D40C173E /* Signing+ResponseVerification.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Signing+ResponseVerification.swift"; path = "Sources/Security/Signing+ResponseVerification.swift"; sourceTree = "<group>"; };
+		71C54285A3DD42FF51B4474B47AE9E1D /* NetworkStrings.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = NetworkStrings.swift; path = Sources/Logging/Strings/NetworkStrings.swift; sourceTree = "<group>"; };
+		73C4084C22CDEC98C11010C872AFC826 /* CustomerAPI.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CustomerAPI.swift; path = Sources/Networking/CustomerAPI.swift; sourceTree = "<group>"; };
+		74A3C88613D4EB0E63038367698A81E9 /* RevenueCat */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = RevenueCat; path = RevenueCat.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		75555DCAAE7414FCBE960E04DCBF4648 /* Localizable.strings */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.strings; name = Localizable.strings; path = ko.lproj/Localizable.strings; sourceTree = "<group>"; };
+		765E212E32A562E75433380D634AE665 /* RateLimiter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = RateLimiter.swift; path = Sources/Misc/RateLimiter.swift; sourceTree = "<group>"; };
+		769EC5FD932E66F04E09F83EBBA8302E /* TemplateViewConfiguration.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = TemplateViewConfiguration.swift; path = RevenueCatUI/Data/TemplateViewConfiguration.swift; sourceTree = "<group>"; };
+		77597392A7F0B2A81AC84D5C39E107E9 /* Clock.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Clock.swift; path = Sources/Misc/DateAndTime/Clock.swift; sourceTree = "<group>"; };
+		775B974FC4B89E31A32A3BEAAFA3714D /* BackendError.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BackendError.swift; path = "Sources/Error Handling/BackendError.swift"; sourceTree = "<group>"; };
+		77AC2BFEB533A0A7A27733B4D78DF05B /* Pods-RevenueCatUIProxy-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-RevenueCatUIProxy-dummy.m"; sourceTree = "<group>"; };
+		7AEDD299A97325A391D005AD569CCC55 /* TemplateViewConfiguration+Extensions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "TemplateViewConfiguration+Extensions.swift"; path = "RevenueCatUI/Data/TemplateViewConfiguration+Extensions.swift"; sourceTree = "<group>"; };
+		7AFB393B2D5C4E4FEEEE40ADC65E6934 /* EntitlementInfos.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = EntitlementInfos.swift; path = Sources/Purchasing/EntitlementInfos.swift; sourceTree = "<group>"; };
+		7C2FFA9D4E6ECD228EEFCD6C5AA96B39 /* DateFormatter+Extensions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "DateFormatter+Extensions.swift"; path = "Sources/LocalReceiptParsing/DataConverters/DateFormatter+Extensions.swift"; sourceTree = "<group>"; };
+		7CFC3FE300E018D5A9F4DD6341661206 /* PaywallExtensions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PaywallExtensions.swift; path = Sources/Support/PaywallExtensions.swift; sourceTree = "<group>"; };
+		7D8FAFBA4428425593792C6F0847CFAC /* Offerings.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Offerings.swift; path = Sources/Purchasing/Offerings.swift; sourceTree = "<group>"; };
+		7DE9CD47D163261AD58E749451BDD743 /* ASN1Container.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ASN1Container.swift; path = Sources/LocalReceiptParsing/BasicTypes/ASN1Container.swift; sourceTree = "<group>"; };
+		7FDC3504D3D207532A27EEE4C25D13D3 /* SwiftUI.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SwiftUI.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS14.0.sdk/System/Library/Frameworks/SwiftUI.framework; sourceTree = DEVELOPER_DIR; };
+		7FFBCBA2C4A5A56499AAEE7841262133 /* AnyDecodable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AnyDecodable.swift; path = Sources/Misc/Codable/AnyDecodable.swift; sourceTree = "<group>"; };
+		80310C067C73962F88A6354DCE6F5564 /* SK1StoreTransaction.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SK1StoreTransaction.swift; path = Sources/Purchasing/StoreKitAbstractions/SK1StoreTransaction.swift; sourceTree = "<group>"; };
+		80AEF9BFD1FACBC73E5CFDAA573C4475 /* PostReceiptDataOperation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PostReceiptDataOperation.swift; path = Sources/Networking/Operations/PostReceiptDataOperation.swift; sourceTree = "<group>"; };
+		80C436F8F9F838F0098B1C0CE04B001B /* TestStoreProduct.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = TestStoreProduct.swift; path = "Sources/Purchasing/StoreKitAbstractions/Test Data/TestStoreProduct.swift"; sourceTree = "<group>"; };
+		815A1120079A6F4715100801E714382F /* Localizable.strings */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.strings; name = Localizable.strings; path = sk.lproj/Localizable.strings; sourceTree = "<group>"; };
+		81631C437A3D05C00ADCB40149D88AF3 /* HTTPRequestPath.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = HTTPRequestPath.swift; path = Sources/Networking/HTTPClient/HTTPRequestPath.swift; sourceTree = "<group>"; };
+		840E180E3D822EC9EAC7942B662A1ADA /* OfferingsManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = OfferingsManager.swift; path = Sources/Purchasing/OfferingsManager.swift; sourceTree = "<group>"; };
+		8460F8943928A50639622E13E5EADFB6 /* AnyEncodable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AnyEncodable.swift; path = Sources/Misc/Codable/AnyEncodable.swift; sourceTree = "<group>"; };
+		8474631B52639B79C38E81B8668CCDEB /* CustomerInfoResponse.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CustomerInfoResponse.swift; path = Sources/Networking/Responses/CustomerInfoResponse.swift; sourceTree = "<group>"; };
+		85E13D987593242F795289E45796ACA9 /* CustomerInfoStrings.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CustomerInfoStrings.swift; path = Sources/Logging/Strings/CustomerInfoStrings.swift; sourceTree = "<group>"; };
+		86AC49434CFE36F0364007173F6A9496 /* LocalReceiptFetcher.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = LocalReceiptFetcher.swift; path = Sources/LocalReceiptParsing/LocalReceiptFetcher.swift; sourceTree = "<group>"; };
+		86D50AFAF70D472CCD93816B32E1E40B /* EntitlementInfo.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = EntitlementInfo.swift; path = Sources/Purchasing/EntitlementInfo.swift; sourceTree = "<group>"; };
+		873D800AA818919D9159417972EF4B6F /* PaywallData+Validation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "PaywallData+Validation.swift"; path = "RevenueCatUI/Data/PaywallData+Validation.swift"; sourceTree = "<group>"; };
+		8745784440E8D38B132D52D48EF29B1D /* TrialOrIntroEligibilityChecker+TestData.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "TrialOrIntroEligibilityChecker+TestData.swift"; path = "RevenueCatUI/Data/IntroEligibility/TrialOrIntroEligibilityChecker+TestData.swift"; sourceTree = "<group>"; };
+		876BDFA86D36230FD2F8D80E5B92FF08 /* Localizable.strings */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.strings; name = Localizable.strings; path = bg.lproj/Localizable.strings; sourceTree = "<group>"; };
+		8786DE2D3899CA84A23124293133F29D /* Template5View.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Template5View.swift; path = RevenueCatUI/Templates/Template5View.swift; sourceTree = "<group>"; };
+		8806DD886666D23BF01A025A15962DFE /* Lock.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Lock.swift; path = Sources/Misc/Concurrency/Lock.swift; sourceTree = "<group>"; };
+		89F546C6D8FA5F5AE01F6E6686A69AA9 /* Date+Extensions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Date+Extensions.swift"; path = "Sources/FoundationExtensions/Date+Extensions.swift"; sourceTree = "<group>"; };
+		8A0B29E7788D6873A17E04AFA7EBCE23 /* icons.xcassets */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = folder.assetcatalog; name = icons.xcassets; path = RevenueCatUI/Resources/icons.xcassets; sourceTree = "<group>"; };
+		8A2ADFA53C6DA7111B4E15FC295182AF /* StoreKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = StoreKit.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS14.0.sdk/System/Library/Frameworks/StoreKit.framework; sourceTree = DEVELOPER_DIR; };
+		8A9FBDAE0B629A66FE29A3CC6BEA0FFC /* ConsistentPackageContentView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ConsistentPackageContentView.swift; path = RevenueCatUI/Modifiers/ConsistentPackageContentView.swift; sourceTree = "<group>"; };
+		8B8074F3E9EA3898A8907EB50B40E81E /* ResourceBundle-RevenueCat_RevenueCatUI-RevenueCatUI-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "ResourceBundle-RevenueCat_RevenueCatUI-RevenueCatUI-Info.plist"; sourceTree = "<group>"; };
+		8CA8CBFD5F5575535E02F38D5A390DCE /* CustomerInfo+NonSubscriptions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "CustomerInfo+NonSubscriptions.swift"; path = "Sources/Identity/CustomerInfo+NonSubscriptions.swift"; sourceTree = "<group>"; };
+		8CF3C1E92A5A1BBBF9DB188C96E1B029 /* PaywallPurchasesType.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PaywallPurchasesType.swift; path = RevenueCatUI/Purchasing/PaywallPurchasesType.swift; sourceTree = "<group>"; };
+		8CF406DD0954F76D42A36AA352494730 /* ASN1ObjectIdentifier.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ASN1ObjectIdentifier.swift; path = Sources/LocalReceiptParsing/BasicTypes/ASN1ObjectIdentifier.swift; sourceTree = "<group>"; };
+		8D1AA55328DB1CCC616D5AEFB964B5CF /* MacDevice.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = MacDevice.swift; path = Sources/Misc/MacDevice.swift; sourceTree = "<group>"; };
+		8F7D68DA0D16CB2E56828F7B6EBB1CEC /* Optional+Extensions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Optional+Extensions.swift"; path = "Sources/FoundationExtensions/Optional+Extensions.swift"; sourceTree = "<group>"; };
+		8F7F005517F4D15A4B80E917238D97D0 /* PurchaseButton.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PurchaseButton.swift; path = RevenueCatUI/Views/PurchaseButton.swift; sourceTree = "<group>"; };
+		8F862FAF96D5F54F1F5C3E95CC4EA5F1 /* RedirectLoggerTaskDelegate.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = RedirectLoggerTaskDelegate.swift; path = Sources/Networking/HTTPClient/RedirectLoggerTaskDelegate.swift; sourceTree = "<group>"; };
+		9006E032BABD4A5FA569CBDE9DCC55CD /* BackendConfiguration.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BackendConfiguration.swift; path = Sources/Networking/BackendConfiguration.swift; sourceTree = "<group>"; };
+		9068A239BDF55599D3B57F207FB961FF /* Localizable.strings */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.strings; name = Localizable.strings; path = fr_CA.lproj/Localizable.strings; sourceTree = "<group>"; };
+		90D5BA2A086A5A3874581563CD5206B7 /* SKError+Extensions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "SKError+Extensions.swift"; path = "Sources/Error Handling/SKError+Extensions.swift"; sourceTree = "<group>"; };
+		91244FDBE84FA037454459DC29E1858E /* Localizable.strings */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.strings; name = Localizable.strings; path = de.lproj/Localizable.strings; sourceTree = "<group>"; };
+		9313E4468561E9486B77FFA016FC1F5C /* HTTPRequest.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = HTTPRequest.swift; path = Sources/Networking/HTTPClient/HTTPRequest.swift; sourceTree = "<group>"; };
+		9321B7F3F9A2EF3DBB5683904363FB45 /* CachingProductsManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CachingProductsManager.swift; path = Sources/Purchasing/CachingProductsManager.swift; sourceTree = "<group>"; };
+		9325999737B5A2ECFC64CFDFB1E93231 /* Logger.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Logger.swift; path = RevenueCatUI/Helpers/Logger.swift; sourceTree = "<group>"; };
+		935E87795CAAD846150968F8B3752459 /* Pods-RevenueCatUIProxy-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-RevenueCatUIProxy-Info.plist"; sourceTree = "<group>"; };
+		93CBCB44837C8E7B15AA6A728953E280 /* Localizable.strings */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.strings; name = Localizable.strings; path = da.lproj/Localizable.strings; sourceTree = "<group>"; };
+		93E73B891FAE8B5450B4F7FBDE77C30D /* NetworkOperation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = NetworkOperation.swift; path = Sources/Networking/Operations/NetworkOperation.swift; sourceTree = "<group>"; };
+		949DF1470B57EA96817DB8874B33D485 /* Localizable.strings */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.strings; name = Localizable.strings; path = pl.lproj/Localizable.strings; sourceTree = "<group>"; };
+		962024FBFCFC7841404BE1BFB84163E2 /* PeriodType+Extensions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "PeriodType+Extensions.swift"; path = "Sources/CodableExtensions/PeriodType+Extensions.swift"; sourceTree = "<group>"; };
+		97719782A8CF27506B99BF4DFD2C7B30 /* CustomerInfo+ActiveDates.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "CustomerInfo+ActiveDates.swift"; path = "Sources/Identity/CustomerInfo+ActiveDates.swift"; sourceTree = "<group>"; };
+		97D0D1959F6DD6F6AC29861544009780 /* Data+Extensions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Data+Extensions.swift"; path = "Sources/FoundationExtensions/Data+Extensions.swift"; sourceTree = "<group>"; };
+		987465897488AC3AB163EA8DFCDFF86C /* InAppPurchase.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = InAppPurchase.swift; path = Sources/LocalReceiptParsing/BasicTypes/InAppPurchase.swift; sourceTree = "<group>"; };
+		989F308620052EE1D83F48AEAD7B0139 /* Store+Extensions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Store+Extensions.swift"; path = "Sources/CodableExtensions/Store+Extensions.swift"; sourceTree = "<group>"; };
+		99248F1D6403FEB9BF0D84404EDB4B0A /* OfferingsFactory.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = OfferingsFactory.swift; path = Sources/Purchasing/OfferingsFactory.swift; sourceTree = "<group>"; };
+		998DBC62E94BC55964B527144787C753 /* MapAppStoreDetector.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = MapAppStoreDetector.swift; path = Sources/Misc/MapAppStoreDetector.swift; sourceTree = "<group>"; };
+		99B44BFFC4A2AE6869703B50E5AF1635 /* Localizable.strings */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.strings; name = Localizable.strings; path = el.lproj/Localizable.strings; sourceTree = "<group>"; };
+		99BAC9ABF5F87CE3AFBC4044FF5EC559 /* OfferingsResponse.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = OfferingsResponse.swift; path = Sources/Networking/Responses/OfferingsResponse.swift; sourceTree = "<group>"; };
+		9A68A4CC5B85F96D96A4C6DF4876CB17 /* ProductsRequestFactory.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ProductsRequestFactory.swift; path = Sources/Purchasing/ProductsRequestFactory.swift; sourceTree = "<group>"; };
+		9D5DDEB1136F23F125C6FAF1C669B61D /* ProductEntitlementMapping.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ProductEntitlementMapping.swift; path = Sources/OfflineEntitlements/ProductEntitlementMapping.swift; sourceTree = "<group>"; };
+		9D940727FF8FB9C785EB98E56350EF41 /* Podfile */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; indentWidth = 2; lastKnownFileType = text; name = Podfile; path = ../Podfile; sourceTree = SOURCE_ROOT; tabWidth = 2; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
+		9E46233E5702053711B7E54132935CF3 /* TrialOrIntroPriceEligibilityChecker.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = TrialOrIntroPriceEligibilityChecker.swift; path = Sources/Purchasing/TrialOrIntroPriceEligibilityChecker.swift; sourceTree = "<group>"; };
+		9F06FA5B5D42E0DE0B76950C22E00DD3 /* IntroEligibilityViewModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = IntroEligibilityViewModel.swift; path = RevenueCatUI/Data/IntroEligibility/IntroEligibilityViewModel.swift; sourceTree = "<group>"; };
+		9FAD6F55E6D19A33516999C74B213279 /* PaywallViewConfiguration.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PaywallViewConfiguration.swift; path = RevenueCatUI/Data/PaywallViewConfiguration.swift; sourceTree = "<group>"; };
+		9FD8F6B5B973819E7FB007789C700295 /* Localizable.strings */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.strings; name = Localizable.strings; path = fi.lproj/Localizable.strings; sourceTree = "<group>"; };
+		9FE59D06B676356311DEBC9409E7BDEE /* TestData.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = TestData.swift; path = RevenueCatUI/Data/TestData.swift; sourceTree = "<group>"; };
+		A0C6CF786FCE8C4758D9195D48CDCF5A /* PurchaseHandler.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PurchaseHandler.swift; path = RevenueCatUI/Purchasing/PurchaseHandler.swift; sourceTree = "<group>"; };
+		A11ADE067B216AB469480C2DE84D2D31 /* RevenueCatUI-RevenueCat_RevenueCatUI */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; name = "RevenueCatUI-RevenueCat_RevenueCatUI"; path = RevenueCat_RevenueCatUI.bundle; sourceTree = BUILT_PRODUCTS_DIR; };
+		A13404049810AEB8A84735E0B3F234AE /* ReceiptParsingError.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ReceiptParsingError.swift; path = Sources/LocalReceiptParsing/ReceiptParsingError.swift; sourceTree = "<group>"; };
+		A138B8781D9D42E24FBF354557201650 /* ProductsFetcherSK1.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ProductsFetcherSK1.swift; path = Sources/Purchasing/StoreKit1/ProductsFetcherSK1.swift; sourceTree = "<group>"; };
+		A1D9E89535C03D64F3626746E85A7662 /* HTTPClient.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = HTTPClient.swift; path = Sources/Networking/HTTPClient/HTTPClient.swift; sourceTree = "<group>"; };
+		A1F5C2C607E66A6374454EE05BF24E31 /* HealthOperation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = HealthOperation.swift; path = Sources/Networking/Operations/HealthOperation.swift; sourceTree = "<group>"; };
+		A201EF114FEDA8084514827CE1AFF594 /* CacheFetchPolicy.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CacheFetchPolicy.swift; path = Sources/Networking/Caching/CacheFetchPolicy.swift; sourceTree = "<group>"; };
+		A219A4AF3D0D0F76EE4A2C80F5A6E5EA /* LocalizedAlertError.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = LocalizedAlertError.swift; path = RevenueCatUI/Data/LocalizedAlertError.swift; sourceTree = "<group>"; };
+		A25487D5630F1811A32536B2FC4C59B4 /* RevenueCat-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "RevenueCat-Info.plist"; sourceTree = "<group>"; };
+		A4D4CC263A6389E17856A6F7789920C5 /* PaywallColor.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PaywallColor.swift; path = Sources/Paywalls/PaywallColor.swift; sourceTree = "<group>"; };
+		A4D6545B930EC5A096110298738AD951 /* PlatformInfo.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PlatformInfo.swift; path = Sources/Misc/PlatformInfo.swift; sourceTree = "<group>"; };
+		A508095BB33CBE0C05207224E994391B /* LoadingPaywallView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = LoadingPaywallView.swift; path = RevenueCatUI/Views/LoadingPaywallView.swift; sourceTree = "<group>"; };
+		A54F2FF9E0100C23B0FBD6175AFDB57E /* PaywallViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PaywallViewController.swift; path = RevenueCatUI/UIKit/PaywallViewController.swift; sourceTree = "<group>"; };
+		A562766731C71CF59A1FDFB9C15B669A /* NetworkError.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = NetworkError.swift; path = Sources/Networking/HTTPClient/NetworkError.swift; sourceTree = "<group>"; };
+		A569D3AA76244AC8088DC50D766DB809 /* ManageSubscriptionsStrings.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ManageSubscriptionsStrings.swift; path = Sources/Logging/Strings/ManageSubscriptionsStrings.swift; sourceTree = "<group>"; };
+		A5AC7FBFD03B895826FC614C4E933170 /* DangerousSettings.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DangerousSettings.swift; path = Sources/Misc/DangerousSettings.swift; sourceTree = "<group>"; };
+		A5C93B916C65C38399E62D9C60BB33AA /* ReservedSubscriberAttributes.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ReservedSubscriberAttributes.swift; path = Sources/SubscriberAttributes/ReservedSubscriberAttributes.swift; sourceTree = "<group>"; };
+		A60EFCC74E5629D9B30E5DE6D6A60F2C /* HTTPRequestBody.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = HTTPRequestBody.swift; path = Sources/Networking/HTTPClient/HTTPRequestBody.swift; sourceTree = "<group>"; };
+		A6789762025A2E63C850219BA1FBC82D /* SubscriberAttribute.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SubscriberAttribute.swift; path = Sources/SubscriberAttributes/SubscriberAttribute.swift; sourceTree = "<group>"; };
+		A68DA5DA2F5E58F0D605D2F38DD613BA /* Localizable.strings */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.strings; name = Localizable.strings; path = ms.lproj/Localizable.strings; sourceTree = "<group>"; };
+		A6B0C133844E5CDE425E8C36E87E7435 /* TransactionsFactory.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = TransactionsFactory.swift; path = Sources/Purchasing/TransactionsFactory.swift; sourceTree = "<group>"; };
+		A79B480376A49072749C3E326B72CDA0 /* DebugContentViews.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DebugContentViews.swift; path = Sources/Support/DebugUI/DebugContentViews.swift; sourceTree = "<group>"; };
+		A7C2C119FFFD373528222FEDBE119D52 /* Package.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Package.swift; path = Sources/Purchasing/Package.swift; sourceTree = "<group>"; };
+		A812827A7A0F5D1DBDB11B06E4075936 /* OfflineEntitlementsStrings.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = OfflineEntitlementsStrings.swift; path = Sources/Logging/Strings/OfflineEntitlementsStrings.swift; sourceTree = "<group>"; };
+		A96E181F1B6B0C902B41B9965F33F48E /* PostAdServicesTokenOperation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PostAdServicesTokenOperation.swift; path = Sources/Networking/Operations/PostAdServicesTokenOperation.swift; sourceTree = "<group>"; };
+		A9AF5E494796D1DEB53588A9EA7FC6DE /* AfficheClientProxy.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AfficheClientProxy.swift; path = Sources/Attribution/AfficheClientProxy.swift; sourceTree = "<group>"; };
+		A9CA5C4542686A4B6E99FEE0E21F3A25 /* TemplateBackgroundImageView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = TemplateBackgroundImageView.swift; path = RevenueCatUI/Views/TemplateBackgroundImageView.swift; sourceTree = "<group>"; };
+		AA1A361FA3292AD4EA4440D7617DD0CE /* Localizable.strings */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.strings; name = Localizable.strings; path = ro.lproj/Localizable.strings; sourceTree = "<group>"; };
+		AA2567ED3DCAD2FFE867DBC8DE74D90A /* HTTPRequest+Signing.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "HTTPRequest+Signing.swift"; path = "Sources/Security/HTTPRequest+Signing.swift"; sourceTree = "<group>"; };
+		AAA0E732FEE7141F24E3F4E7A5A773FD /* FileHandler.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = FileHandler.swift; path = Sources/Diagnostics/FileHandler.swift; sourceTree = "<group>"; };
+		AB3F47EE27B2013E2728F6B6B1FCC10A /* OfferingStrings.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = OfferingStrings.swift; path = Sources/Logging/Strings/OfferingStrings.swift; sourceTree = "<group>"; };
+		AB4F48F4F073A35035B878CB24AC4A0E /* RevenueCatUI-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "RevenueCatUI-umbrella.h"; sourceTree = "<group>"; };
+		AC9C2F019F6D720173BD6606CFACE663 /* RawDataContainer.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = RawDataContainer.swift; path = Sources/Misc/Codable/RawDataContainer.swift; sourceTree = "<group>"; };
+		ACAE490B9918D5AC1F9AA96433816789 /* Localizable.strings */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.strings; name = Localizable.strings; path = zh_Hant.lproj/Localizable.strings; sourceTree = "<group>"; };
+		ACD66A2D1313F92B3A877AFECEBC33D7 /* PaywallEventsRequest.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PaywallEventsRequest.swift; path = Sources/Paywalls/Events/Networking/PaywallEventsRequest.swift; sourceTree = "<group>"; };
+		AD02133AC320927349A99B77213060B3 /* OfflineEntitlementsManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = OfflineEntitlementsManager.swift; path = Sources/OfflineEntitlements/OfflineEntitlementsManager.swift; sourceTree = "<group>"; };
+		AE8846676500151FA6F56619CC13D4BF /* EnsureNonEmptyCollectionDecodable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = EnsureNonEmptyCollectionDecodable.swift; path = Sources/Misc/Codable/EnsureNonEmptyCollectionDecodable.swift; sourceTree = "<group>"; };
+		AEFC8E12AF2C71A450E54827C67DCA87 /* ETagManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ETagManager.swift; path = Sources/Networking/HTTPClient/ETagManager.swift; sourceTree = "<group>"; };
+		B002E4D329D936DC8C0D24C71702F403 /* IdentityAPI.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = IdentityAPI.swift; path = Sources/Networking/IdentityAPI.swift; sourceTree = "<group>"; };
+		B05238CFC05F5888B303CB4B9AD99B68 /* Operators+Extensions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Operators+Extensions.swift"; path = "Sources/FoundationExtensions/Operators+Extensions.swift"; sourceTree = "<group>"; };
+		B09AEDC6DEFB78261D36A242BA09B983 /* PurchasesType.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PurchasesType.swift; path = Sources/Purchasing/Purchases/PurchasesType.swift; sourceTree = "<group>"; };
+		B13710EBD419656B8ECE1A32CD356ABA /* ColorInformation+MultiScheme.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "ColorInformation+MultiScheme.swift"; path = "RevenueCatUI/Helpers/ColorInformation+MultiScheme.swift"; sourceTree = "<group>"; };
+		B1A5AC088187B1A3E4E2CF89C5B277CB /* InAppPurchaseBuilder.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = InAppPurchaseBuilder.swift; path = Sources/LocalReceiptParsing/Builders/InAppPurchaseBuilder.swift; sourceTree = "<group>"; };
+		B2FA6AA89A40241CD24FFB5E11FC65BD /* PostAttributionDataOperation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PostAttributionDataOperation.swift; path = Sources/Networking/Operations/PostAttributionDataOperation.swift; sourceTree = "<group>"; };
+		B32EE4C995105DFF7767F02E1C72823F /* IconView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = IconView.swift; path = RevenueCatUI/Views/IconView.swift; sourceTree = "<group>"; };
+		B40E63D923368F867FC605BEE247EE5D /* StoreMessageType.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = StoreMessageType.swift; path = Sources/Support/StoreMessageType.swift; sourceTree = "<group>"; };
+		B4B54BC30CAD951DFA1FAAADA9AD506B /* RevenueCat.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = RevenueCat.modulemap; sourceTree = "<group>"; };
+		B589712FC557590325C8CCFF2B81BC16 /* InternalAPI.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = InternalAPI.swift; path = Sources/Networking/InternalAPI.swift; sourceTree = "<group>"; };
+		B5F557A6C192C2643D827890252BAA2A /* Localizable.strings */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.strings; name = Localizable.strings; path = hi.lproj/Localizable.strings; sourceTree = "<group>"; };
+		B6F938E10F45AF0E92A5EFAF3E6BC733 /* StorefrontProvider.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = StorefrontProvider.swift; path = Sources/Purchasing/StoreKitAbstractions/StorefrontProvider.swift; sourceTree = "<group>"; };
+		B7C8DAAA8FB9091CEF6FC41E30160447 /* Localizable.strings */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.strings; name = Localizable.strings; path = ja.lproj/Localizable.strings; sourceTree = "<group>"; };
+		BA3DD4E616BD75B704078BFBEDF6469A /* Variables.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Variables.swift; path = RevenueCatUI/Data/Variables.swift; sourceTree = "<group>"; };
+		BA923E42D6ED50B7657E73F45A527E08 /* ReceiptStrings.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ReceiptStrings.swift; path = Sources/LocalReceiptParsing/Helpers/ReceiptStrings.swift; sourceTree = "<group>"; };
+		BB481D2492ABB41E4FA555A662785F3C /* PaywallEventStore.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PaywallEventStore.swift; path = Sources/Paywalls/Events/PaywallEventStore.swift; sourceTree = "<group>"; };
+		BB79074395CA71664B624679C88EC9C3 /* LogIntent.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = LogIntent.swift; path = Sources/Logging/LogIntent.swift; sourceTree = "<group>"; };
+		BBBC56A8E1AFF6F6AEEDD1B5FEEC4251 /* AppleReceiptBuilder.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AppleReceiptBuilder.swift; path = Sources/LocalReceiptParsing/Builders/AppleReceiptBuilder.swift; sourceTree = "<group>"; };
+		BC110E03FF4B22E124E1A6E1263FC0F8 /* FitToAspectRatio.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = FitToAspectRatio.swift; path = RevenueCatUI/Modifiers/FitToAspectRatio.swift; sourceTree = "<group>"; };
+		BC84B2418BCFA843623765703ADA8A18 /* Constants.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Constants.swift; path = RevenueCatUI/Data/Constants.swift; sourceTree = "<group>"; };
+		BD727195107FE62E1616C528C7887982 /* Backend.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Backend.swift; path = Sources/Networking/Backend.swift; sourceTree = "<group>"; };
+		BED43C5AAB71F3545DFBDD88EAA849EB /* ProcessedLocalizedConfiguration.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ProcessedLocalizedConfiguration.swift; path = RevenueCatUI/Data/ProcessedLocalizedConfiguration.swift; sourceTree = "<group>"; };
+		BF1D27EF667400D5DE4CEAAEFF862205 /* IdentityManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = IdentityManager.swift; path = Sources/Identity/IdentityManager.swift; sourceTree = "<group>"; };
+		BFD2BC0CAD3FBD8C1838A8DC2C976B90 /* BackendErrorStrings.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BackendErrorStrings.swift; path = Sources/Logging/Strings/BackendErrorStrings.swift; sourceTree = "<group>"; };
+		BFF24DFA67346D283AEDAC36C87812F9 /* AttributionPoster.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AttributionPoster.swift; path = Sources/Attribution/AttributionPoster.swift; sourceTree = "<group>"; };
+		C00076B3ACF9832943483521408B1282 /* LogInCallback.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = LogInCallback.swift; path = Sources/Networking/Caching/LogInCallback.swift; sourceTree = "<group>"; };
+		C17E96ABEE65166EC8F3D05DE6AE7629 /* PaymentQueueWrapper.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PaymentQueueWrapper.swift; path = Sources/Purchasing/StoreKit1/PaymentQueueWrapper.swift; sourceTree = "<group>"; };
+		C2348A832CBA44EDE63364DB1986FB60 /* ProductRequestData+Initialization.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "ProductRequestData+Initialization.swift"; path = "Sources/Purchasing/ProductRequestData+Initialization.swift"; sourceTree = "<group>"; };
+		C5371208E84A3229D8B19F9E8DF380A5 /* Array+Extensions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Array+Extensions.swift"; path = "Sources/FoundationExtensions/Array+Extensions.swift"; sourceTree = "<group>"; };
+		C6436F36D08B15F4C86F4489539F0EBF /* AppleReceipt.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AppleReceipt.swift; path = Sources/LocalReceiptParsing/BasicTypes/AppleReceipt.swift; sourceTree = "<group>"; };
+		C6F87F25863D57D386A7A864CFCAB20B /* CustomerInfo.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CustomerInfo.swift; path = Sources/Identity/CustomerInfo.swift; sourceTree = "<group>"; };
+		C886F097E968C8A7A5E40F85BF4EA750 /* SK2StoreTransaction.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SK2StoreTransaction.swift; path = Sources/Purchasing/StoreKitAbstractions/SK2StoreTransaction.swift; sourceTree = "<group>"; };
+		C8E73EB3897D5A452488D372720E174B /* PurchasedProductsFetcher.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PurchasedProductsFetcher.swift; path = Sources/OfflineEntitlements/PurchasedProductsFetcher.swift; sourceTree = "<group>"; };
+		C927F3733C9038CED0547C8ED3B55006 /* TimingUtil.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = TimingUtil.swift; path = Sources/Misc/DateAndTime/TimingUtil.swift; sourceTree = "<group>"; };
+		C9F5171509593BA208283A9E48B49AC5 /* GetOfferingsOperation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = GetOfferingsOperation.swift; path = Sources/Networking/Operations/GetOfferingsOperation.swift; sourceTree = "<group>"; };
+		CAC18679C0CA1E2F5E54AED127B14105 /* Localizable.strings */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.strings; name = Localizable.strings; path = pt_PT.lproj/Localizable.strings; sourceTree = "<group>"; };
+		CC07D373D9C6DE500E9BEEC24CF19C90 /* RevenueCat-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "RevenueCat-prefix.pch"; sourceTree = "<group>"; };
+		CC999C381929373550AAA80279F27C52 /* StoreKitWorkarounds.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = StoreKitWorkarounds.swift; path = Sources/Purchasing/StoreKitAbstractions/StoreKitWorkarounds.swift; sourceTree = "<group>"; };
+		CD4E745D50E7D6F25C396B11F6ED87E3 /* Localizable.strings */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.strings; name = Localizable.strings; path = en_GB.lproj/Localizable.strings; sourceTree = "<group>"; };
+		CDE874B719E1D43667CC22191CE22C82 /* PurchaseOwnershipType+Extensions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "PurchaseOwnershipType+Extensions.swift"; path = "Sources/CodableExtensions/PurchaseOwnershipType+Extensions.swift"; sourceTree = "<group>"; };
+		CE1EEE7DABC48AAFE5903AE56EE0E86B /* StoreKitStrings.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = StoreKitStrings.swift; path = Sources/Logging/Strings/StoreKitStrings.swift; sourceTree = "<group>"; };
+		D04A7EF15B202B8A7A75501912C9494B /* StoreProduct.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = StoreProduct.swift; path = Sources/Purchasing/StoreKitAbstractions/StoreProduct.swift; sourceTree = "<group>"; };
+		D0D03186241780644F5974DB27D4DDA8 /* NonSubscriptionTransaction.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = NonSubscriptionTransaction.swift; path = Sources/Purchasing/NonSubscriptionTransaction.swift; sourceTree = "<group>"; };
+		D0F76AC9DA6F7A91784197B8F038A738 /* PurchasesError.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PurchasesError.swift; path = "Sources/Error Handling/PurchasesError.swift"; sourceTree = "<group>"; };
+		D19117EF24D1DEA008C42692B3DFB0EB /* PaywallFontProvider.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PaywallFontProvider.swift; path = RevenueCatUI/PaywallFontProvider.swift; sourceTree = "<group>"; };
+		D1D03A4D74963BEC22962AA075B632F3 /* PurchasedSK2Product.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PurchasedSK2Product.swift; path = Sources/OfflineEntitlements/PurchasedSK2Product.swift; sourceTree = "<group>"; };
+		D1EB560E06C3561F232AB47F9DE11659 /* ProcessInfo+Extensions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "ProcessInfo+Extensions.swift"; path = "Sources/LocalReceiptParsing/Helpers/ProcessInfo+Extensions.swift"; sourceTree = "<group>"; };
+		D404C4770BBF4D9D2E995B6121EBC98C /* IntroEligibility.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = IntroEligibility.swift; path = Sources/Purchasing/IntroEligibility.swift; sourceTree = "<group>"; };
+		D42E1CB6DF06A1988C5DB694EEE4A725 /* DateExtensions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DateExtensions.swift; path = Sources/Misc/DateAndTime/DateExtensions.swift; sourceTree = "<group>"; };
+		D591E6468FEBB719BED28B96D1C37306 /* PurchasesReceiptParser.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PurchasesReceiptParser.swift; path = Sources/LocalReceiptParsing/PurchasesReceiptParser.swift; sourceTree = "<group>"; };
+		D608699E7764EC351B37B87E66504D16 /* PaywallView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PaywallView.swift; path = RevenueCatUI/PaywallView.swift; sourceTree = "<group>"; };
+		D6A274A2B1498303B33B3868C8C1AC4F /* Attribution.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Attribution.swift; path = Sources/Purchasing/Purchases/Attribution.swift; sourceTree = "<group>"; };
+		D71FBFA350BE6E2A0AA1EEB91BFA3DE7 /* ProductsFetcherSK2.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ProductsFetcherSK2.swift; path = Sources/Purchasing/StoreKit2/ProductsFetcherSK2.swift; sourceTree = "<group>"; };
+		D7EFD14B0A93572C43C2D13BB54CC923 /* SigningStrings.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SigningStrings.swift; path = Sources/Logging/Strings/SigningStrings.swift; sourceTree = "<group>"; };
+		D8226A5D9E5747AA532C84FB572704B3 /* ImageLoader.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ImageLoader.swift; path = RevenueCatUI/Helpers/ImageLoader.swift; sourceTree = "<group>"; };
+		D89BA3BEC5F6718F547544EE09B8523E /* ErrorResponse.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ErrorResponse.swift; path = Sources/Networking/HTTPClient/ErrorResponse.swift; sourceTree = "<group>"; };
+		D9E6AE1E820BAD23D10A3D29AB732089 /* PaywallData+Localization.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "PaywallData+Localization.swift"; path = "Sources/Paywalls/PaywallData+Localization.swift"; sourceTree = "<group>"; };
+		DAA6F4DB54FE48AC3E186008A105709F /* Strings.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Strings.swift; path = Sources/Logging/Strings/Strings.swift; sourceTree = "<group>"; };
+		DB6855FC01EDEF698EA925CCD5718546 /* StoreKitError+Extensions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "StoreKitError+Extensions.swift"; path = "Sources/Error Handling/StoreKitError+Extensions.swift"; sourceTree = "<group>"; };
+		DCA9E79A59113D86C1186ADA0D1E5108 /* RevenueCat-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "RevenueCat-dummy.m"; sourceTree = "<group>"; };
+		DCABD1DE4D5CF1130BF4A166C1DD26F0 /* Pods-RevenueCatUIProxy */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = "Pods-RevenueCatUIProxy"; path = Pods_RevenueCatUIProxy.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		DCC02CA3FC3C4EB4597206BE1D53C9DE /* Localizable.strings */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.strings; name = Localizable.strings; path = th.lproj/Localizable.strings; sourceTree = "<group>"; };
+		DDD87483360DAE06679FC5FF83BB9B92 /* HTTPStatusCode.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = HTTPStatusCode.swift; path = Sources/Networking/HTTPClient/HTTPStatusCode.swift; sourceTree = "<group>"; };
+		DE359CCD53E08DB5B8A42BA69C05EBD1 /* ArraySlice_UInt8+Extensions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "ArraySlice_UInt8+Extensions.swift"; path = "Sources/LocalReceiptParsing/DataConverters/ArraySlice_UInt8+Extensions.swift"; sourceTree = "<group>"; };
+		DEC4549FC46AE7A6492CE90C1D4DCA23 /* ErrorDetails.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ErrorDetails.swift; path = "Sources/Error Handling/ErrorDetails.swift"; sourceTree = "<group>"; };
+		DECE704283A407E168DCF9F043E27ACE /* CustomerInfoManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CustomerInfoManager.swift; path = Sources/Identity/CustomerInfoManager.swift; sourceTree = "<group>"; };
+		E2778FE803F904FE7F788822FC919935 /* Signing.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Signing.swift; path = Sources/Security/Signing.swift; sourceTree = "<group>"; };
+		E465680BCC264263781260D01F710AC7 /* PostSubscriberAttributesOperation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PostSubscriberAttributesOperation.swift; path = Sources/Networking/Operations/PostSubscriberAttributesOperation.swift; sourceTree = "<group>"; };
+		E4A8C873408216E15B19A15C494031BA /* RevenueCatUI-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "RevenueCatUI-dummy.m"; sourceTree = "<group>"; };
+		E6C0C4A916C327F7DF923E7B5D71D5CC /* ErrorDisplay.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ErrorDisplay.swift; path = RevenueCatUI/Views/ErrorDisplay.swift; sourceTree = "<group>"; };
+		E6E01D10B8A7F3609D7E429C35FC6862 /* Package+VariableDataProvider.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Package+VariableDataProvider.swift"; path = "RevenueCatUI/Helpers/Package+VariableDataProvider.swift"; sourceTree = "<group>"; };
+		E77BA889ABE506F57687B5A3626D83A5 /* Atomic.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Atomic.swift; path = Sources/Misc/Concurrency/Atomic.swift; sourceTree = "<group>"; };
+		E84E49A66DC290DF15DE0BD29E3C5F63 /* Codable+Extensions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Codable+Extensions.swift"; path = "Sources/LocalReceiptParsing/DataConverters/Codable+Extensions.swift"; sourceTree = "<group>"; };
+		E9DAE3BCB86E6AB6729DE0B9C56BFFB7 /* ASIdManagerProxy.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ASIdManagerProxy.swift; path = Sources/Attribution/ASIdManagerProxy.swift; sourceTree = "<group>"; };
+		EA0CA1344A1BBEA20F49B33D6CFA80E4 /* AttributionTypeFactory.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AttributionTypeFactory.swift; path = Sources/Attribution/AttributionTypeFactory.swift; sourceTree = "<group>"; };
+		EAC29964EE7FD66D8328C25801C25C37 /* TransactionPoster.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = TransactionPoster.swift; path = Sources/Purchasing/Purchases/TransactionPoster.swift; sourceTree = "<group>"; };
+		EB48A0D50ECB8E8D1644A7F8ABCE01B8 /* DispatchTimeInterval+Extensions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "DispatchTimeInterval+Extensions.swift"; path = "Sources/FoundationExtensions/DispatchTimeInterval+Extensions.swift"; sourceTree = "<group>"; };
+		EB6AFAAB6438F6F1C4A40622ECDF46B9 /* TemplateError.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = TemplateError.swift; path = RevenueCatUI/Data/Errors/TemplateError.swift; sourceTree = "<group>"; };
+		EC46D683AB4593573D11FF6681C5B5A4 /* RevenueCat-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "RevenueCat-umbrella.h"; sourceTree = "<group>"; };
+		EE8EAFC5963CEF92448114B8CF032CBF /* UIApplication+RCExtensions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "UIApplication+RCExtensions.swift"; path = "Sources/FoundationExtensions/UIApplication+RCExtensions.swift"; sourceTree = "<group>"; };
+		EFB920147612D6EA7D0D6FD94A75B86E /* StoreKitRequestFetcher.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = StoreKitRequestFetcher.swift; path = Sources/Purchasing/StoreKit1/StoreKitRequestFetcher.swift; sourceTree = "<group>"; };
+		F169557230E3E27C5CD7BDB53091447A /* Localizable.strings */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.strings; name = Localizable.strings; path = es_419.lproj/Localizable.strings; sourceTree = "<group>"; };
+		F1952DAE6C6B1C7F1AF7763D2178E4D4 /* Localizable.strings */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.strings; name = Localizable.strings; path = uk.lproj/Localizable.strings; sourceTree = "<group>"; };
+		F5517B4B885C7E387071BB7B318046AB /* Localizable.strings */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.strings; name = Localizable.strings; path = en.lproj/Localizable.strings; sourceTree = "<group>"; };
+		F63E219033C4B04B2233CB269AF79429 /* Localizable.strings */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.strings; name = Localizable.strings; path = en_CA.lproj/Localizable.strings; sourceTree = "<group>"; };
+		F78AE86FCC6762CCEB9674F05ACF5B7D /* PaywallViewMode.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PaywallViewMode.swift; path = Sources/Paywalls/PaywallViewMode.swift; sourceTree = "<group>"; };
+		F7AD91C1CD6F70BD092991445FA03F8B /* CustomerInfoCallback.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CustomerInfoCallback.swift; path = Sources/Networking/Caching/CustomerInfoCallback.swift; sourceTree = "<group>"; };
+		F89477023283EA4BA1BCF6BB20B5861B /* PriceFormatterProvider.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PriceFormatterProvider.swift; path = Sources/Misc/PriceFormatterProvider.swift; sourceTree = "<group>"; };
+		F8FC9D7C0BFA6196FDE4E2F548C4ED78 /* IntroEligibilityStateView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = IntroEligibilityStateView.swift; path = RevenueCatUI/Views/IntroEligibilityStateView.swift; sourceTree = "<group>"; };
+		F94EA08A727DBE34A0EF45BB71A2C2E7 /* Localizable.strings */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.strings; name = Localizable.strings; path = en_US.lproj/Localizable.strings; sourceTree = "<group>"; };
+		F9957F1A607198552234434CDC033E9F /* Localizable.strings */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.strings; name = Localizable.strings; path = he.lproj/Localizable.strings; sourceTree = "<group>"; };
+		F9E365105A769FC052A58E244D969BE4 /* Localizable.strings */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.strings; name = Localizable.strings; path = no.lproj/Localizable.strings; sourceTree = "<group>"; };
+		FA38F44871620BD4FE0212F0B54879D1 /* IntroEligibilityCalculator.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = IntroEligibilityCalculator.swift; path = Sources/Purchasing/IntroEligibilityCalculator.swift; sourceTree = "<group>"; };
+		FA8572878BBBEBE1F8479BEDF923B1BA /* CachingTrialOrIntroPriceEligibilityChecker.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CachingTrialOrIntroPriceEligibilityChecker.swift; path = Sources/Purchasing/CachingTrialOrIntroPriceEligibilityChecker.swift; sourceTree = "<group>"; };
+		FBE6DCD8F6BA05E23B12495A97ED3992 /* OfflineEntitlementsAPI.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = OfflineEntitlementsAPI.swift; path = Sources/Networking/OfflineEntitlementsAPI.swift; sourceTree = "<group>"; };
+		FC3263E242A6B3C66808B6735D5C606F /* TemplateViewConfiguration+Images.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "TemplateViewConfiguration+Images.swift"; path = "RevenueCatUI/Data/TemplateViewConfiguration+Images.swift"; sourceTree = "<group>"; };
+		FC60E361A6C5031053E5812E1ABBE2F4 /* Localizable.strings */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.strings; name = Localizable.strings; path = vi.lproj/Localizable.strings; sourceTree = "<group>"; };
+		FD2E2D1123673CA38A911895CAAB2313 /* Storefront.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Storefront.swift; path = Sources/Purchasing/StoreKitAbstractions/Storefront.swift; sourceTree = "<group>"; };
+		FD3A3592FC72EC9F7F58EAEAFD7C03DB /* PaywallEventsManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PaywallEventsManager.swift; path = Sources/Paywalls/Events/PaywallEventsManager.swift; sourceTree = "<group>"; };
+		FDBF93BBEBD6D0F518870B962042019F /* OperationDispatcher.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = OperationDispatcher.swift; path = Sources/Misc/Concurrency/OperationDispatcher.swift; sourceTree = "<group>"; };
+		FDDC0E25268564B494DD9A75733F3725 /* Localizable.strings */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.strings; name = Localizable.strings; path = es_ES.lproj/Localizable.strings; sourceTree = "<group>"; };
+		FE25FA99DDBA18EB97347F9BC48B2496 /* Purchases+nonasync.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Purchases+nonasync.swift"; path = "Sources/Misc/Concurrency/Purchases+nonasync.swift"; sourceTree = "<group>"; };
+		FE29ABC278A4DDFE424B7A9631081AE0 /* OfferingsAPI.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = OfferingsAPI.swift; path = Sources/Networking/OfferingsAPI.swift; sourceTree = "<group>"; };
+		FE78FC7AF28DDEDFBDFA9C66A5CA05D3 /* PaywallFooterViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PaywallFooterViewController.swift; path = RevenueCatUI/UIKit/PaywallFooterViewController.swift; sourceTree = "<group>"; };
+		FEBAD9DFF50057516FBF8496F9AA3AD8 /* DNSChecker.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DNSChecker.swift; path = Sources/Networking/HTTPClient/DNSChecker.swift; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		24A0B916A59B80ACE5CCBD57EE1E5681 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				0F3C1D770691D7479D3AB5D5E54B34A8 /* Foundation.framework in Frameworks */,
+				1F03D0F6EA0859EB7F55F66BF42392DF /* StoreKit.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		4D484DCE0DCA1F1511CF8D5858807D4D /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				26F4443465CE0C5D21F099B9049B66E7 /* Foundation.framework in Frameworks */,
+				073E4BF5193061F2CE03961ABC3A0B6E /* SwiftUI.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		9483AF77F001654A8E190BCD6AE834AC /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		F854BC4C13ECC93FF3FA68E31A30E816 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				A858B521D3928AE7B04E9D587EBBE00E /* Foundation.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		03C5C200A0787E300053CFA8F53CA094 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				5FCD78AAD9A00B834381FFBA96496510 /* iOS */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		135BB6CBA2040FCE2E099C5F3D329DEC /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				DCABD1DE4D5CF1130BF4A166C1DD26F0 /* Pods-RevenueCatUIProxy */,
+				74A3C88613D4EB0E63038367698A81E9 /* RevenueCat */,
+				357F0C3821C69EA9072751220A9E4CFC /* RevenueCatUI */,
+				A11ADE067B216AB469480C2DE84D2D31 /* RevenueCatUI-RevenueCat_RevenueCatUI */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		270097A63DB24D1E2D0AC305DA6325EC /* Targets Support Files */ = {
+			isa = PBXGroup;
+			children = (
+				CEC1BAE57DF5B6F3E1BB8FE63B6BC1A4 /* Pods-RevenueCatUIProxy */,
+			);
+			name = "Targets Support Files";
+			sourceTree = "<group>";
+		};
+		2CAFA28775E396E617E516D9E7BDCFC4 /* RevenueCat */ = {
+			isa = PBXGroup;
+			children = (
+				A9AF5E494796D1DEB53588A9EA7FC6DE /* AfficheClientProxy.swift */,
+				7FFBCBA2C4A5A56499AAEE7841262133 /* AnyDecodable.swift */,
+				8460F8943928A50639622E13E5EADFB6 /* AnyEncodable.swift */,
+				C6436F36D08B15F4C86F4489539F0EBF /* AppleReceipt.swift */,
+				BBBC56A8E1AFF6F6AEEDD1B5FEEC4251 /* AppleReceiptBuilder.swift */,
+				C5371208E84A3229D8B19F9E8DF380A5 /* Array+Extensions.swift */,
+				DE359CCD53E08DB5B8A42BA69C05EBD1 /* ArraySlice_UInt8+Extensions.swift */,
+				E9DAE3BCB86E6AB6729DE0B9C56BFFB7 /* ASIdManagerProxy.swift */,
+				7DE9CD47D163261AD58E749451BDD743 /* ASN1Container.swift */,
+				5448EFDDD99FB7B52C918ED932A253F6 /* ASN1ContainerBuilder.swift */,
+				8CF406DD0954F76D42A36AA352494730 /* ASN1ObjectIdentifier.swift */,
+				6615C5A368D81A525045230D4EEF894F /* ASN1ObjectIdentifierBuilder.swift */,
+				30DF6F969560A7C4881C71B84720218F /* Assertions.swift */,
+				034DECCA994D46B6BCED9C208E232D60 /* AsyncExtensions.swift */,
+				E77BA889ABE506F57687B5A3626D83A5 /* Atomic.swift */,
+				D6A274A2B1498303B33B3868C8C1AC4F /* Attribution.swift */,
+				46B538D4275ACB6D2A16D4ECFE619F44 /* AttributionData.swift */,
+				3D4BD6CCCEE68209D38D974AC89C2FE3 /* AttributionDataMigrator.swift */,
+				1A598E5E0F263DBE91FD61575F46786F /* AttributionFetcher.swift */,
+				1D8D1ADBCEA973D31C7B2D2C54027B26 /* AttributionKey.swift */,
+				21C1E1098345081ABAF01BA2A8E876FB /* AttributionNetwork.swift */,
+				BFF24DFA67346D283AEDAC36C87812F9 /* AttributionPoster.swift */,
+				5FDEBCE68D047156CC4491F401F822C0 /* AttributionStrings.swift */,
+				EA0CA1344A1BBEA20F49B33D6CFA80E4 /* AttributionTypeFactory.swift */,
+				BD727195107FE62E1616C528C7887982 /* Backend.swift */,
+				9006E032BABD4A5FA569CBDE9DCC55CD /* BackendConfiguration.swift */,
+				775B974FC4B89E31A32A3BEAAFA3714D /* BackendError.swift */,
+				5AF51E27768FD1642CFC3162DA97AB6B /* BackendErrorCode.swift */,
+				BFD2BC0CAD3FBD8C1838A8DC2C976B90 /* BackendErrorStrings.swift */,
+				48E6993B79D76DCDFDCA7689A4ACC8B7 /* BeginRefundRequestHelper.swift */,
+				6033FA7AF38C1F87F0BB91E10EEACBD2 /* Box.swift */,
+				A201EF114FEDA8084514827CE1AFF594 /* CacheFetchPolicy.swift */,
+				9321B7F3F9A2EF3DBB5683904363FB45 /* CachingProductsManager.swift */,
+				FA8572878BBBEBE1F8479BEDF923B1BA /* CachingTrialOrIntroPriceEligibilityChecker.swift */,
+				4922199D5683E03888AE7BCFADB60703 /* CallbackCache.swift */,
+				7142C9AD45DFD689443A103A599A3693 /* CallbackCacheStatus.swift */,
+				77597392A7F0B2A81AC84D5C39E107E9 /* Clock.swift */,
+				E84E49A66DC290DF15DE0BD29E3C5F63 /* Codable+Extensions.swift */,
+				2CA9CE285EAB9403D4FA61784F244DD6 /* CodableStrings.swift */,
+				67DA97684D19FD71B9EF56DF251D6E20 /* Configuration.swift */,
+				0419E764195EDDC1046E8940A59B8985 /* ConfigureStrings.swift */,
+				73C4084C22CDEC98C11010C872AFC826 /* CustomerAPI.swift */,
+				C6F87F25863D57D386A7A864CFCAB20B /* CustomerInfo.swift */,
+				97719782A8CF27506B99BF4DFD2C7B30 /* CustomerInfo+ActiveDates.swift */,
+				8CA8CBFD5F5575535E02F38D5A390DCE /* CustomerInfo+NonSubscriptions.swift */,
+				0052237C8F47C201B87019F8E3B3D4E9 /* CustomerInfo+OfflineEntitlements.swift */,
+				F7AD91C1CD6F70BD092991445FA03F8B /* CustomerInfoCallback.swift */,
+				DECE704283A407E168DCF9F043E27ACE /* CustomerInfoManager.swift */,
+				8474631B52639B79C38E81B8668CCDEB /* CustomerInfoResponse.swift */,
+				0D9EF3D22D8759B4F58CD80511161030 /* CustomerInfoResponseHandler.swift */,
+				85E13D987593242F795289E45796ACA9 /* CustomerInfoStrings.swift */,
+				A5AC7FBFD03B895826FC614C4E933170 /* DangerousSettings.swift */,
+				97D0D1959F6DD6F6AC29861544009780 /* Data+Extensions.swift */,
+				89F546C6D8FA5F5AE01F6E6686A69AA9 /* Date+Extensions.swift */,
+				D42E1CB6DF06A1988C5DB694EEE4A725 /* DateExtensions.swift */,
+				7C2FFA9D4E6ECD228EEFCD6C5AA96B39 /* DateFormatter+Extensions.swift */,
+				2FE85C9B0C62CB2237635DFC367C935E /* DateProvider.swift */,
+				A79B480376A49072749C3E326B72CDA0 /* DebugContentViews.swift */,
+				5F4775BD35B655C01C21D38D0C99A400 /* DebugView.swift */,
+				1628C9B7F9C3B39A0EE2661659144691 /* DebugViewController.swift */,
+				2E54795119F90AFB6D67DCC19F3D83B4 /* DebugViewModel.swift */,
+				6D7021A1B5D6CC4892057D59033AEB68 /* DebugViewSheetPresentation.swift */,
+				0E454A81509B8947AC746BB2DACF1D90 /* Decoder+Extensions.swift */,
+				222131C342DD6835365FA5048A996250 /* DefaultDecodable.swift */,
+				43B64DF06A7ED3B998E74B51AF14BAFC /* Deprecations.swift */,
+				13B0CB406CF2B1448F56735252C8D71C /* DescribableError.swift */,
+				44A9FA068FE7DBF0A30AD0985845010E /* DeviceCache.swift */,
+				4560C1E5ED8F09031BE6D4B5B5CDF727 /* DiagnosticsStrings.swift */,
+				1C2554ECF1D573B9C52E9F96796B9A0E /* Dictionary+Extensions.swift */,
+				EB48A0D50ECB8E8D1644A7F8ABCE01B8 /* DispatchTimeInterval+Extensions.swift */,
+				FEBAD9DFF50057516FBF8496F9AA3AD8 /* DNSChecker.swift */,
+				6843F70FDDD5F5EA8EB0C7BFE1393CA2 /* Either.swift */,
+				0F8A9C1F4DF9F62BD23CFF55676028E1 /* EligibilityStrings.swift */,
+				0BF147FC220F89E895718029DDA23718 /* EmptyFile.swift */,
+				2E9AFF147D2310B1DE529DBBA90B216B /* EncodedAppleReceipt.swift */,
+				AE8846676500151FA6F56619CC13D4BF /* EnsureNonEmptyCollectionDecodable.swift */,
+				86D50AFAF70D472CCD93816B32E1E40B /* EntitlementInfo.swift */,
+				7AFB393B2D5C4E4FEEEE40ADC65E6934 /* EntitlementInfos.swift */,
+				14A5ACBE79C0A9EF7DE745D39FE974A0 /* Error+Extensions.swift */,
+				06E5399767DAD7EA0AADC5104A54C55B /* ErrorCode.swift */,
+				DEC4549FC46AE7A6492CE90C1D4DCA23 /* ErrorDetails.swift */,
+				D89BA3BEC5F6718F547544EE09B8523E /* ErrorResponse.swift */,
+				2B7394E4FA5715231A66BECB05871209 /* ErrorUtils.swift */,
+				AEFC8E12AF2C71A450E54827C67DCA87 /* ETagManager.swift */,
+				0C18DEAA6661BFE23A38B1CB3BFB940A /* ETagStrings.swift */,
+				0101944FD91EA7AD3C015C203B23C41D /* FakeSigning.swift */,
+				AAA0E732FEE7141F24E3F4E7A5A773FD /* FileHandler.swift */,
+				137AD66CF50C1F471559B1C457D0B9EE /* FileReader.swift */,
+				5EF63ABD9CCDBA84E50E3E8EC01DE837 /* FrameworkDisambiguation.swift */,
+				0B0C1CD9109C6C6934435F40D7566338 /* GetCustomerInfoOperation.swift */,
+				32F5E6BC7E0B3F3B80716DF65F718732 /* GetIntroEligibilityOperation.swift */,
+				585C576BCECE23BC51069949ED78CBED /* GetIntroEligibilityResponse.swift */,
+				C9F5171509593BA208283A9E48B49AC5 /* GetOfferingsOperation.swift */,
+				1015E76DED97C427C4AC84304ABD8B99 /* GetProductEntitlementMappingOperation.swift */,
+				A1F5C2C607E66A6374454EE05BF24E31 /* HealthOperation.swift */,
+				A1D9E89535C03D64F3626746E85A7662 /* HTTPClient.swift */,
+				9313E4468561E9486B77FFA016FC1F5C /* HTTPRequest.swift */,
+				AA2567ED3DCAD2FFE867DBC8DE74D90A /* HTTPRequest+Signing.swift */,
+				A60EFCC74E5629D9B30E5DE6D6A60F2C /* HTTPRequestBody.swift */,
+				40AE340C6D312EAEAA74A3262E66DB53 /* HTTPRequestBody+Signing.swift */,
+				81631C437A3D05C00ADCB40149D88AF3 /* HTTPRequestPath.swift */,
+				053471365AC83C6665EC2185F7C5DB6D /* HTTPResponse.swift */,
+				621B0F39F41EB5C138A9381BEEDD73D3 /* HTTPResponseBody.swift */,
+				DDD87483360DAE06679FC5FF83BB9B92 /* HTTPStatusCode.swift */,
+				B002E4D329D936DC8C0D24C71702F403 /* IdentityAPI.swift */,
+				BF1D27EF667400D5DE4CEAAEFF862205 /* IdentityManager.swift */,
+				25FA20A35B1C18890DA652125D391EAF /* IdentityStrings.swift */,
+				3DE57DB635EA829EBEDA10D7FBB436F8 /* IgnoreHashable.swift */,
+				987465897488AC3AB163EA8DFCDFF86C /* InAppPurchase.swift */,
+				B1A5AC088187B1A3E4E2CF89C5B277CB /* InAppPurchaseBuilder.swift */,
+				6C07E7D145AD32E7B349F50196E9D472 /* InMemoryCachedObject.swift */,
+				53E24F8FE1375A9E933203DFC5C06759 /* Integer+Extensions.swift */,
+				B589712FC557590325C8CCFF2B81BC16 /* InternalAPI.swift */,
+				D404C4770BBF4D9D2E995B6121EBC98C /* IntroEligibility.swift */,
+				FA38F44871620BD4FE0212F0B54879D1 /* IntroEligibilityCalculator.swift */,
+				1D773688C1E38F7BD47217D67B401202 /* ISOPeriodFormatter.swift */,
+				4DCF45CE4D6986498F68051BF600585B /* Locale+Extensions.swift */,
+				86AC49434CFE36F0364007173F6A9496 /* LocalReceiptFetcher.swift */,
+				8806DD886666D23BF01A025A15962DFE /* Lock.swift */,
+				117C91FD3ABC917953962A303F46588A /* Logger.swift */,
+				689F831F8BE8C1B1C6C08CC4223E7C0B /* LoggerType.swift */,
+				C00076B3ACF9832943483521408B1282 /* LogInCallback.swift */,
+				61CF97E5EE29C235E2D75FBFC1389782 /* LogInOperation.swift */,
+				BB79074395CA71664B624679C88EC9C3 /* LogIntent.swift */,
+				8D1AA55328DB1CCC616D5AEFB964B5CF /* MacDevice.swift */,
+				2D9E714CB697615148A5906730122F42 /* ManageSubscriptionsHelper.swift */,
+				A569D3AA76244AC8088DC50D766DB809 /* ManageSubscriptionsStrings.swift */,
+				998DBC62E94BC55964B527144787C753 /* MapAppStoreDetector.swift */,
+				A562766731C71CF59A1FDFB9C15B669A /* NetworkError.swift */,
+				93E73B891FAE8B5450B4F7FBDE77C30D /* NetworkOperation.swift */,
+				71C54285A3DD42FF51B4474B47AE9E1D /* NetworkStrings.swift */,
+				0D5274C800BC3283A9BCF045ABAB89E9 /* NonEmptyStringDecodable.swift */,
+				D0D03186241780644F5974DB27D4DDA8 /* NonSubscriptionTransaction.swift */,
+				485D3A527946E757618BEC7D14F65D2E /* Obsoletions.swift */,
+				372EE7ABE674EA19272F3A4F0FC6DDF3 /* Offering.swift */,
+				7D8FAFBA4428425593792C6F0847CFAC /* Offerings.swift */,
+				FE29ABC278A4DDFE424B7A9631081AE0 /* OfferingsAPI.swift */,
+				6321ABC8B416568CCD2ABFFE29455F67 /* OfferingsCallback.swift */,
+				99248F1D6403FEB9BF0D84404EDB4B0A /* OfferingsFactory.swift */,
+				840E180E3D822EC9EAC7942B662A1ADA /* OfferingsManager.swift */,
+				99BAC9ABF5F87CE3AFBC4044FF5EC559 /* OfferingsResponse.swift */,
+				AB3F47EE27B2013E2728F6B6B1FCC10A /* OfferingStrings.swift */,
+				1765ADD1D0C7468CC4CC8B7EA3E1FD09 /* OfflineCustomerInfoCreator.swift */,
+				FBE6DCD8F6BA05E23B12495A97ED3992 /* OfflineEntitlementsAPI.swift */,
+				AD02133AC320927349A99B77213060B3 /* OfflineEntitlementsManager.swift */,
+				A812827A7A0F5D1DBDB11B06E4075936 /* OfflineEntitlementsStrings.swift */,
+				FDBF93BBEBD6D0F518870B962042019F /* OperationDispatcher.swift */,
+				3333D851B66855FCC88037DA067972F5 /* OperationQueue+Extensions.swift */,
+				B05238CFC05F5888B303CB4B9AD99B68 /* Operators+Extensions.swift */,
+				8F7D68DA0D16CB2E56828F7B6EBB1CEC /* Optional+Extensions.swift */,
+				A7C2C119FFFD373528222FEDBE119D52 /* Package.swift */,
+				2A4E0B1ED911611F228210AAB8F55782 /* PackageType.swift */,
+				C17E96ABEE65166EC8F3D05DE6AE7629 /* PaymentQueueWrapper.swift */,
+				31816E7AF5B16DE42937CD24ED83E20D /* PaywallCacheWarming.swift */,
+				A4D4CC263A6389E17856A6F7789920C5 /* PaywallColor.swift */,
+				14B426F1B92DD2C66583E6C29D7B01B4 /* PaywallData.swift */,
+				D9E6AE1E820BAD23D10A3D29AB732089 /* PaywallData+Localization.swift */,
+				4837F9FEC3E3C7809E628FBCA94EEF67 /* PaywallEvent.swift */,
+				47FDB7A0628B5B9951743BBF97ABCC7A /* PaywallEventSerializer.swift */,
+				FD3A3592FC72EC9F7F58EAEAFD7C03DB /* PaywallEventsManager.swift */,
+				ACD66A2D1313F92B3A877AFECEBC33D7 /* PaywallEventsRequest.swift */,
+				BB481D2492ABB41E4FA555A662785F3C /* PaywallEventStore.swift */,
+				7CFC3FE300E018D5A9F4DD6341661206 /* PaywallExtensions.swift */,
+				3858205357F8B2DDA9C988D7AABA7489 /* PaywallHTTPRequestPath.swift */,
+				3CCCBD19E9BD2D38AD333A3AD5328EC4 /* PaywallsStrings.swift */,
+				1E20C245A924BD3C35AB64A1D16C417B /* PaywallStoredEvent.swift */,
+				F78AE86FCC6762CCEB9674F05ACF5B7D /* PaywallViewMode.swift */,
+				962024FBFCFC7841404BE1BFB84163E2 /* PeriodType+Extensions.swift */,
+				A4D6545B930EC5A096110298738AD951 /* PlatformInfo.swift */,
+				A96E181F1B6B0C902B41B9965F33F48E /* PostAdServicesTokenOperation.swift */,
+				B2FA6AA89A40241CD24FFB5E11FC65BD /* PostAttributionDataOperation.swift */,
+				3CD58377164B1105465F5DACD097B975 /* PostOfferForSigningOperation.swift */,
+				506856395E0C6776C54614F07BD6C60F /* PostOfferResponse.swift */,
+				674F47EFB90EAACA6A5717B6E77532C0 /* PostPaywallEventsOperation.swift */,
+				80AEF9BFD1FACBC73E5CFDAA573C4475 /* PostReceiptDataOperation.swift */,
+				E465680BCC264263781260D01F710AC7 /* PostSubscriberAttributesOperation.swift */,
+				F89477023283EA4BA1BCF6BB20B5861B /* PriceFormatterProvider.swift */,
+				D1EB560E06C3561F232AB47F9DE11659 /* ProcessInfo+Extensions.swift */,
+				9D5DDEB1136F23F125C6FAF1C669B61D /* ProductEntitlementMapping.swift */,
+				2308FBF7951C8C0A9766F5B0041B96CD /* ProductEntitlementMappingCallback.swift */,
+				4F151C45B517CDAF823A8E8FCC2339DD /* ProductEntitlementMappingFetcher.swift */,
+				5268F6651D7ECE855E7A42C8C4EC7C99 /* ProductEntitlementMappingResponse.swift */,
+				3C17E266D5A3121C791A3F4D7D01C54D /* ProductRequestData.swift */,
+				C2348A832CBA44EDE63364DB1986FB60 /* ProductRequestData+Initialization.swift */,
+				A138B8781D9D42E24FBF354557201650 /* ProductsFetcherSK1.swift */,
+				D71FBFA350BE6E2A0AA1EEB91BFA3DE7 /* ProductsFetcherSK2.swift */,
+				2C0E330B41826951A072A6A252EE374D /* ProductsManager.swift */,
+				9A68A4CC5B85F96D96A4C6DF4876CB17 /* ProductsRequestFactory.swift */,
+				2A14D5B64519109F3593E787ED24ACCE /* ProductType.swift */,
+				2A06C922790FDFE1B4BD74209DB5E11B /* PromotionalOffer.swift */,
+				C8E73EB3897D5A452488D372720E174B /* PurchasedProductsFetcher.swift */,
+				D1D03A4D74963BEC22962AA075B632F3 /* PurchasedSK2Product.swift */,
+				23D8FDF2B1102058AAC884CE43EDA0D0 /* PurchaseOwnershipType.swift */,
+				CDE874B719E1D43667CC22191CE22C82 /* PurchaseOwnershipType+Extensions.swift */,
+				01C6E8CDE817B89AF6687351BB2E760A /* Purchases.swift */,
+				12B490CCDAAAC6E5C8FD853D3A7B1049 /* Purchases+async.swift */,
+				FE25FA99DDBA18EB97347F9BC48B2496 /* Purchases+nonasync.swift */,
+				1D82FDC22586B0B4387FCCB4BFB50CD4 /* PurchasesDelegate.swift */,
+				1C0848DD5307985FCBF2D148277E556E /* PurchasesDiagnostics.swift */,
+				D0F76AC9DA6F7A91784197B8F038A738 /* PurchasesError.swift */,
+				20ACED2DAF329A74B31102084342FB10 /* PurchasesOrchestrator.swift */,
+				D591E6468FEBB719BED28B96D1C37306 /* PurchasesReceiptParser.swift */,
+				6684D4C6BC54402CB322B27DBFC2F379 /* PurchaseStrings.swift */,
+				B09AEDC6DEFB78261D36A242BA09B983 /* PurchasesType.swift */,
+				765E212E32A562E75433380D634AE665 /* RateLimiter.swift */,
+				AC9C2F019F6D720173BD6606CFACE663 /* RawDataContainer.swift */,
+				178AA9CFB3106D2B67393570C1724C6B /* ReceiptFetcher.swift */,
+				55F9D886F2028AF4A70F1639A5F1B193 /* ReceiptParserLogger.swift */,
+				A13404049810AEB8A84735E0B3F234AE /* ReceiptParsingError.swift */,
+				2E6DCB7DC4901FD63CCDDAE222A20EF7 /* ReceiptRefreshPolicy.swift */,
+				BA923E42D6ED50B7657E73F45A527E08 /* ReceiptStrings.swift */,
+				8F862FAF96D5F54F1F5C3E95CC4EA5F1 /* RedirectLoggerTaskDelegate.swift */,
+				A5C93B916C65C38399E62D9C60BB33AA /* ReservedSubscriberAttributes.swift */,
+				68518B3344CC25984CAFD8D47D65FE6B /* Result+Extensions.swift */,
+				1A267014AAE8F350958902647265514C /* SandboxEnvironmentDetector.swift */,
+				4E8EEFF0916467A473EDC2705419D8AC /* Set+Extensions.swift */,
+				E2778FE803F904FE7F788822FC919935 /* Signing.swift */,
+				715411EDCA987814596E51D5D40C173E /* Signing+ResponseVerification.swift */,
+				D7EFD14B0A93572C43C2D13BB54CC923 /* SigningStrings.swift */,
+				4632275F8ECBCABA3EF959CB510B50A6 /* SK1Storefront.swift */,
+				03A3FC674FBD50C2ACF0FCAF4A1715E4 /* SK1StoreProduct.swift */,
+				5FF4B2CCBE3A9020A6F6BE3EF4A4EE0E /* SK1StoreProductDiscount.swift */,
+				80310C067C73962F88A6354DCE6F5564 /* SK1StoreTransaction.swift */,
+				700B7847A5AAA7AF5105CD1019B84002 /* SK2AppTransaction.swift */,
+				334E024B920045978835E0253D39407D /* SK2BeginRefundRequestHelper.swift */,
+				1EE9CBD6F97E39B55366105608A72B9B /* SK2Storefront.swift */,
+				3CE96248BEF99DDC1E7850CB57FDDEB0 /* SK2StoreProduct.swift */,
+				605FAED5A8B4D8E8444DE897D121B3BC /* SK2StoreProductDiscount.swift */,
+				C886F097E968C8A7A5E40F85BF4EA750 /* SK2StoreTransaction.swift */,
+				90D5BA2A086A5A3874581563CD5206B7 /* SKError+Extensions.swift */,
+				989F308620052EE1D83F48AEAD7B0139 /* Store+Extensions.swift */,
+				1AF82E31C65331D8A1A6CD1B3D40CB50 /* StoreEnvironment.swift */,
+				FD2E2D1123673CA38A911895CAAB2313 /* Storefront.swift */,
+				B6F938E10F45AF0E92A5EFAF3E6BC733 /* StorefrontProvider.swift */,
+				38A77254A36685B116565ACACF9116A2 /* StoreKit1Wrapper.swift */,
+				66710A8DB807A32CCF920B02C1218D22 /* StoreKit2Receipt.swift */,
+				5184776B9AC1C9A7DA509C2297014A09 /* StoreKit2Setting.swift */,
+				30A7B6E022ADC514EDEEC4F09D1FB374 /* StoreKit2StorefrontListener.swift */,
+				3C00696A7C38211D433C22DC147D2264 /* StoreKit2TransactionFetcher.swift */,
+				457785D495E608B772FF2A41CF66CDED /* StoreKit2TransactionListener.swift */,
+				DB6855FC01EDEF698EA925CCD5718546 /* StoreKitError+Extensions.swift */,
+				EFB920147612D6EA7D0D6FD94A75B86E /* StoreKitRequestFetcher.swift */,
+				CE1EEE7DABC48AAFE5903AE56EE0E86B /* StoreKitStrings.swift */,
+				CC999C381929373550AAA80279F27C52 /* StoreKitWorkarounds.swift */,
+				2CAF63F71AE6CF8C74E21584DBE6DF89 /* StoreMessagesHelper.swift */,
+				B40E63D923368F867FC605BEE247EE5D /* StoreMessageType.swift */,
+				D04A7EF15B202B8A7A75501912C9494B /* StoreProduct.swift */,
+				237F87F13D4BD6EF1C8B0AC49A8E9370 /* StoreProductDiscount.swift */,
+				2E99153681E0D8F6D4C642F824A866F9 /* StoreTransaction.swift */,
+				1D12C677933E69762F563CAF9D81A475 /* String+Extensions.swift */,
+				DAA6F4DB54FE48AC3E186008A105709F /* Strings.swift */,
+				A6789762025A2E63C850219BA1FBC82D /* SubscriberAttribute.swift */,
+				0C892F5517EDE2CCE92333D5214BF6C9 /* SubscriberAttributesManager.swift */,
+				430B7A74CC7D58F29E38A9E253A6936C /* SubscriptionPeriod.swift */,
+				5140E08D3EA6B021076F31151B61F5DB /* SwiftVersionCheck.swift */,
+				017BDCE2D2662FA6A493CF1BFB25B6A4 /* SynchronizedUserDefaults.swift */,
+				65F8FB72680A164D17E715E2D9BA11A7 /* SystemInfo.swift */,
+				80C436F8F9F838F0098B1C0CE04B001B /* TestStoreProduct.swift */,
+				58F7BCD9188AFAED6E5B54753313FFAF /* TestStoreProductDiscount.swift */,
+				C927F3733C9038CED0547C8ED3B55006 /* TimingUtil.swift */,
+				2204801CE2EC17213FD239AE398508E4 /* TrackingManagerProxy.swift */,
+				EAC29964EE7FD66D8328C25801C25C37 /* TransactionPoster.swift */,
+				A6B0C133844E5CDE425E8C36E87E7435 /* TransactionsFactory.swift */,
+				1B6A4EABEDDA29B13EA2006FBDF9F895 /* TransactionsManager.swift */,
+				9E46233E5702053711B7E54132935CF3 /* TrialOrIntroPriceEligibilityChecker.swift */,
+				EE8EAFC5963CEF92448114B8CF032CBF /* UIApplication+RCExtensions.swift */,
+				55A776A74CE9ADEC37DA5F29D75DA961 /* UInt8+Extensions.swift */,
+				049DE7D491B9ABFCDEB8331755E541C2 /* UserDefaults+Extensions.swift */,
+				13F73941C6E2F9A432BDD964F8D635E5 /* VerificationResult.swift */,
+				87CB9CA787CDE5B099EBE714796FCFB4 /* Support Files */,
+			);
+			name = RevenueCat;
+			path = RevenueCat;
+			sourceTree = "<group>";
+		};
+		3A4A0B6618FE59DE521C9FD0E745D18E /* Support Files */ = {
+			isa = PBXGroup;
+			children = (
+				8B8074F3E9EA3898A8907EB50B40E81E /* ResourceBundle-RevenueCat_RevenueCatUI-RevenueCatUI-Info.plist */,
+				6A8E7C9C32D49E2DAC904653C469E28F /* RevenueCatUI.modulemap */,
+				E4A8C873408216E15B19A15C494031BA /* RevenueCatUI-dummy.m */,
+				424C4326E46065FCEC6CD8779751DFC5 /* RevenueCatUI-Info.plist */,
+				1D6C1E088788A6FB0072DC9428290C99 /* RevenueCatUI-prefix.pch */,
+				AB4F48F4F073A35035B878CB24AC4A0E /* RevenueCatUI-umbrella.h */,
+				026CA7DFD3D5AB3571B6EBC7ADB35A2A /* RevenueCatUI.debug.xcconfig */,
+				4039D362E6B5E36F2FA9A4571C5451F3 /* RevenueCatUI.release.xcconfig */,
+			);
+			name = "Support Files";
+			path = "../Target Support Files/RevenueCatUI";
+			sourceTree = "<group>";
+		};
+		42DA2DA130473731A9984BFFD25C61D6 /* RevenueCatUI */ = {
+			isa = PBXGroup;
+			children = (
+				6E2CAC070D3FD34A0B997D67849A9651 /* AsyncButton.swift */,
+				04DC4F5D389AE04EEDF3898FF00F04DE /* Bundle+Extensions.swift */,
+				B13710EBD419656B8ECE1A32CD356ABA /* ColorInformation+MultiScheme.swift */,
+				8A9FBDAE0B629A66FE29A3CC6BEA0FFC /* ConsistentPackageContentView.swift */,
+				BC84B2418BCFA843623765703ADA8A18 /* Constants.swift */,
+				1F7240EE6A5EFE74509BD484A0588DF4 /* DebugErrorView.swift */,
+				E6C0C4A916C327F7DF923E7B5D71D5CC /* ErrorDisplay.swift */,
+				BC110E03FF4B22E124E1A6E1263FC0F8 /* FitToAspectRatio.swift */,
+				3245B97509D7C05BD0B1EFA77CBB7624 /* FooterHidingModifier.swift */,
+				23CEF064C5B5ABF69F1ABBA1ACE5B1AA /* FooterView.swift */,
+				B32EE4C995105DFF7767F02E1C72823F /* IconView.swift */,
+				D8226A5D9E5747AA532C84FB572704B3 /* ImageLoader.swift */,
+				F8FC9D7C0BFA6196FDE4E2F548C4ED78 /* IntroEligibilityStateView.swift */,
+				9F06FA5B5D42E0DE0B76950C22E00DD3 /* IntroEligibilityViewModel.swift */,
+				A508095BB33CBE0C05207224E994391B /* LoadingPaywallView.swift */,
+				6702401664EC1391F906C9451C19B780 /* Localization.swift */,
+				A219A4AF3D0D0F76EE4A2C80F5A6E5EA /* LocalizedAlertError.swift */,
+				9325999737B5A2ECFC64CFDFB1E93231 /* Logger.swift */,
+				5830B063A00F011FD05D7453D10BF423 /* MockPurchases.swift */,
+				5E3B60AAB45031386B36873ADBF71D52 /* Optional+Extensions.swift */,
+				E6E01D10B8A7F3609D7E429C35FC6862 /* Package+VariableDataProvider.swift */,
+				5E48A52143B096EFAC48DF76EB9AB992 /* PackageButtonStyle.swift */,
+				2D0D558FED95668F69D2BDAC461E7337 /* PaywallData+Default.swift */,
+				873D800AA818919D9159417972EF4B6F /* PaywallData+Validation.swift */,
+				447660A1325B3D6BA209156F274EB920 /* PaywallError.swift */,
+				D19117EF24D1DEA008C42692B3DFB0EB /* PaywallFontProvider.swift */,
+				FE78FC7AF28DDEDFBDFA9C66A5CA05D3 /* PaywallFooterViewController.swift */,
+				8CF3C1E92A5A1BBBF9DB188C96E1B029 /* PaywallPurchasesType.swift */,
+				41C9477D371661E8E7C3BF93A1434D74 /* PaywallTemplate.swift */,
+				D608699E7764EC351B37B87E66504D16 /* PaywallView.swift */,
+				9FAD6F55E6D19A33516999C74B213279 /* PaywallViewConfiguration.swift */,
+				A54F2FF9E0100C23B0FBD6175AFDB57E /* PaywallViewController.swift */,
+				5EE436FCBE03A50CFE0BFDED3248991D /* PaywallViewMode+Extensions.swift */,
+				34034DAE3C091E4478F25FCD36D74A3E /* PreviewHelpers.swift */,
+				BED43C5AAB71F3545DFBDD88EAA849EB /* ProcessedLocalizedConfiguration.swift */,
+				37A59D4BA7C39F3C2CFB7178B3FC4CE7 /* ProgressView.swift */,
+				8F7F005517F4D15A4B80E917238D97D0 /* PurchaseButton.swift */,
+				A0C6CF786FCE8C4758D9195D48CDCF5A /* PurchaseHandler.swift */,
+				3597BF99FB7D38A634D97D665FBFE1A0 /* PurchaseHandler+TestData.swift */,
+				0BD9BCBBA86BC162F7E3B9F5FA3E3822 /* RemoteImage.swift */,
+				6C632E78406DB8D85F72A8B774394728 /* Strings.swift */,
+				4EDBF31628D5E3EB2E2815F9A40BAD4A /* Template1View.swift */,
+				2145099333FBAEEB8A7DD4BC2ADB176F /* Template2View.swift */,
+				25CBF776E957DAA2944AC2FE58157502 /* Template3View.swift */,
+				06E245E6676726EB6576F1AC42ED9278 /* Template4View.swift */,
+				8786DE2D3899CA84A23124293133F29D /* Template5View.swift */,
+				A9CA5C4542686A4B6E99FEE0E21F3A25 /* TemplateBackgroundImageView.swift */,
+				EB6AFAAB6438F6F1C4A40622ECDF46B9 /* TemplateError.swift */,
+				769EC5FD932E66F04E09F83EBBA8302E /* TemplateViewConfiguration.swift */,
+				7AEDD299A97325A391D005AD569CCC55 /* TemplateViewConfiguration+Extensions.swift */,
+				FC3263E242A6B3C66808B6735D5C606F /* TemplateViewConfiguration+Images.swift */,
+				0F3323B15F06428E6B106BCCC35F99DF /* TemplateViewType.swift */,
+				9FE59D06B676356311DEBC9409E7BDEE /* TestData.swift */,
+				42470306638B63A79F5841EE989E46F9 /* TrialOrIntroEligibilityChecker.swift */,
+				8745784440E8D38B132D52D48EF29B1D /* TrialOrIntroEligibilityChecker+TestData.swift */,
+				65D5E2CD27BF5A77B217D577012536C6 /* UserInterfaceIdiom.swift */,
+				BA3DD4E616BD75B704078BFBEDF6469A /* Variables.swift */,
+				4949EA4DC67310D8339EFF214B672911 /* VersionDetector.swift */,
+				6AC17DB80457EE71A6F77CD47E80A6CC /* View+PresentPaywall.swift */,
+				3F1BFCA3528D7022573FF89003AA31BA /* View+PresentPaywallFooter.swift */,
+				49DD941877FDE851657A51E48AD31B65 /* View+PurchaseRestoreCompleted.swift */,
+				36B9946F0EB0253FF8CB6EDCBA3253A6 /* ViewExtensions.swift */,
+				6569112F41AB17C8594AA45D46F8A643 /* WatchTemplateView.swift */,
+				8BF95A7852104541045EE6DBB1BCAC8D /* Resources */,
+				3A4A0B6618FE59DE521C9FD0E745D18E /* Support Files */,
+			);
+			name = RevenueCatUI;
+			path = RevenueCatUI;
+			sourceTree = "<group>";
+		};
+		5FCD78AAD9A00B834381FFBA96496510 /* iOS */ = {
+			isa = PBXGroup;
+			children = (
+				45B01B021164958A1A1625CE10CD6777 /* Foundation.framework */,
+				8A2ADFA53C6DA7111B4E15FC295182AF /* StoreKit.framework */,
+				7FDC3504D3D207532A27EEE4C25D13D3 /* SwiftUI.framework */,
+			);
+			name = iOS;
+			sourceTree = "<group>";
+		};
+		87CB9CA787CDE5B099EBE714796FCFB4 /* Support Files */ = {
+			isa = PBXGroup;
+			children = (
+				B4B54BC30CAD951DFA1FAAADA9AD506B /* RevenueCat.modulemap */,
+				DCA9E79A59113D86C1186ADA0D1E5108 /* RevenueCat-dummy.m */,
+				A25487D5630F1811A32536B2FC4C59B4 /* RevenueCat-Info.plist */,
+				CC07D373D9C6DE500E9BEEC24CF19C90 /* RevenueCat-prefix.pch */,
+				EC46D683AB4593573D11FF6681C5B5A4 /* RevenueCat-umbrella.h */,
+				6DFAD98DACDD279298644691491B9F6A /* RevenueCat.debug.xcconfig */,
+				6313B707C269CB3C69585C430AACD82C /* RevenueCat.release.xcconfig */,
+			);
+			name = "Support Files";
+			path = "../Target Support Files/RevenueCat";
+			sourceTree = "<group>";
+		};
+		8BF95A7852104541045EE6DBB1BCAC8D /* Resources */ = {
+			isa = PBXGroup;
+			children = (
+				6F4969D08ABA73D221FE57019A14CDE6 /* background.jpg */,
+				8A0B29E7788D6873A17E04AFA7EBCE23 /* icons.xcassets */,
+				51B9931DD3FB99019456617147804449 /* Localizable.strings */,
+			);
+			name = Resources;
+			sourceTree = "<group>";
+		};
+		CEC1BAE57DF5B6F3E1BB8FE63B6BC1A4 /* Pods-RevenueCatUIProxy */ = {
+			isa = PBXGroup;
+			children = (
+				50D224502BBCC9632B3FA00E5A20D6C0 /* Pods-RevenueCatUIProxy.modulemap */,
+				4655E6676D387C53933381D2DA91A18D /* Pods-RevenueCatUIProxy-acknowledgements.markdown */,
+				6FC6E947C9DCB3A884F01458FF9460F1 /* Pods-RevenueCatUIProxy-acknowledgements.plist */,
+				77AC2BFEB533A0A7A27733B4D78DF05B /* Pods-RevenueCatUIProxy-dummy.m */,
+				935E87795CAAD846150968F8B3752459 /* Pods-RevenueCatUIProxy-Info.plist */,
+				6012F2507EBBCBEB17C818C924F73339 /* Pods-RevenueCatUIProxy-umbrella.h */,
+				4C287E21017EBC7041BEB0F82ECF89B0 /* Pods-RevenueCatUIProxy.debug.xcconfig */,
+				186B06A2048E16FB31CD76A67AF29159 /* Pods-RevenueCatUIProxy.release.xcconfig */,
+			);
+			name = "Pods-RevenueCatUIProxy";
+			path = "Target Support Files/Pods-RevenueCatUIProxy";
+			sourceTree = "<group>";
+		};
+		CF1408CF629C7361332E53B88F7BD30C = {
+			isa = PBXGroup;
+			children = (
+				9D940727FF8FB9C785EB98E56350EF41 /* Podfile */,
+				03C5C200A0787E300053CFA8F53CA094 /* Frameworks */,
+				F96DC043EDC2DD1692B61115C8DACBA6 /* Pods */,
+				135BB6CBA2040FCE2E099C5F3D329DEC /* Products */,
+				270097A63DB24D1E2D0AC305DA6325EC /* Targets Support Files */,
+			);
+			sourceTree = "<group>";
+		};
+		F96DC043EDC2DD1692B61115C8DACBA6 /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				2CAFA28775E396E617E516D9E7BDCFC4 /* RevenueCat */,
+				42DA2DA130473731A9984BFFD25C61D6 /* RevenueCatUI */,
+			);
+			name = Pods;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXHeadersBuildPhase section */
+		95E187AE0B378790737109EA9008E742 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				EFD9CCF9CD9388DA66B7D1553B4DE7C3 /* RevenueCatUI-umbrella.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		D91FF4847C05C714CDD677E0DEA9DF7D /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				F7D76039F3734DA00065430ADC1CDA33 /* Pods-RevenueCatUIProxy-umbrella.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		EFEA68E94DE6AA2F774F1FC43F17A763 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				3B26260ACB37710A387C59887AB4362C /* RevenueCat-umbrella.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXHeadersBuildPhase section */
+
+/* Begin PBXNativeTarget section */
+		A57E526C97CEB07B0DAB27D9FC709692 /* RevenueCatUI */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 5074DF1F4F1F4196D5AE6710A4496636 /* Build configuration list for PBXNativeTarget "RevenueCatUI" */;
+			buildPhases = (
+				95E187AE0B378790737109EA9008E742 /* Headers */,
+				9E823B29C11B1017F6CB289B11E66FF9 /* Sources */,
+				4D484DCE0DCA1F1511CF8D5858807D4D /* Frameworks */,
+				651A56788666F2F63458416630D0E3AD /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				A3713CE348B2218CB7EB98699112F7E2 /* PBXTargetDependency */,
+				1AC8E30E76E404D364F7C9205AA295A7 /* PBXTargetDependency */,
+			);
+			name = RevenueCatUI;
+			productName = RevenueCatUI;
+			productReference = 357F0C3821C69EA9072751220A9E4CFC /* RevenueCatUI */;
+			productType = "com.apple.product-type.framework";
+		};
+		A9FD6F34305C03A1CC3A10B207522C48 /* RevenueCat */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 3870AEDC4D08CA24396A926FDB0AFAE1 /* Build configuration list for PBXNativeTarget "RevenueCat" */;
+			buildPhases = (
+				EFEA68E94DE6AA2F774F1FC43F17A763 /* Headers */,
+				CC8F5F5B73F9D8EA9EE678F2D2388FA3 /* Sources */,
+				24A0B916A59B80ACE5CCBD57EE1E5681 /* Frameworks */,
+				FF5FEEAAAD27218928A6EDEFA0B1A4A4 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = RevenueCat;
+			productName = RevenueCat;
+			productReference = 74A3C88613D4EB0E63038367698A81E9 /* RevenueCat */;
+			productType = "com.apple.product-type.framework";
+		};
+		CF57851EC915911B4B6C714AC16BCFFF /* RevenueCatUI-RevenueCat_RevenueCatUI */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = E44C0A07FE5E4E3AAC6ED8B2E72768BE /* Build configuration list for PBXNativeTarget "RevenueCatUI-RevenueCat_RevenueCatUI" */;
+			buildPhases = (
+				380959975257161685C13C1E6EDDFC1F /* Sources */,
+				9483AF77F001654A8E190BCD6AE834AC /* Frameworks */,
+				737111EF2DE15D2F6DADB60BE6BB4302 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "RevenueCatUI-RevenueCat_RevenueCatUI";
+			productName = RevenueCat_RevenueCatUI;
+			productReference = A11ADE067B216AB469480C2DE84D2D31 /* RevenueCatUI-RevenueCat_RevenueCatUI */;
+			productType = "com.apple.product-type.bundle";
+		};
+		EDC21F3D6443E0853AA9343167D4F4F1 /* Pods-RevenueCatUIProxy */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 4898589D49D92F0B7559C01D1CF71EB5 /* Build configuration list for PBXNativeTarget "Pods-RevenueCatUIProxy" */;
+			buildPhases = (
+				D91FF4847C05C714CDD677E0DEA9DF7D /* Headers */,
+				B92290284CB4286C64187C368ED13078 /* Sources */,
+				F854BC4C13ECC93FF3FA68E31A30E816 /* Frameworks */,
+				74F2F0D70DD856A51F31711F28830B1E /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				8693762801FD48452DBDE3C59653719E /* PBXTargetDependency */,
+				74FF2FEC0935DDA1CA2BD2536B104BE1 /* PBXTargetDependency */,
+			);
+			name = "Pods-RevenueCatUIProxy";
+			productName = Pods_RevenueCatUIProxy;
+			productReference = DCABD1DE4D5CF1130BF4A166C1DD26F0 /* Pods-RevenueCatUIProxy */;
+			productType = "com.apple.product-type.framework";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		BFDFE7DC352907FC980B868725387E98 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastSwiftUpdateCheck = 1500;
+				LastUpgradeCheck = 1500;
+			};
+			buildConfigurationList = 4821239608C13582E20E6DA73FD5F1F9 /* Build configuration list for PBXProject "Pods" */;
+			compatibilityVersion = "Xcode 14.0";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				Base,
+				ar,
+				bg,
+				ca,
+				cs,
+				da,
+				de,
+				el,
+				en,
+				en_AU,
+				en_CA,
+				en_GB,
+				en_US,
+				es_419,
+				es_ES,
+				fi,
+				fr_CA,
+				he,
+				hi,
+				hr,
+				hu,
+				id,
+				it,
+				ja,
+				kk,
+				ko,
+				ms,
+				nl,
+				no,
+				pl,
+				pt_BR,
+				pt_PT,
+				ro,
+				ru,
+				sk,
+				sv,
+				th,
+				tr,
+				uk,
+				vi,
+				zh_Hans,
+				zh_Hant,
+			);
+			mainGroup = CF1408CF629C7361332E53B88F7BD30C;
+			productRefGroup = 135BB6CBA2040FCE2E099C5F3D329DEC /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				EDC21F3D6443E0853AA9343167D4F4F1 /* Pods-RevenueCatUIProxy */,
+				A9FD6F34305C03A1CC3A10B207522C48 /* RevenueCat */,
+				A57E526C97CEB07B0DAB27D9FC709692 /* RevenueCatUI */,
+				CF57851EC915911B4B6C714AC16BCFFF /* RevenueCatUI-RevenueCat_RevenueCatUI */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		651A56788666F2F63458416630D0E3AD /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				705FFD5A68DB23A9AC7797B3A57B2F04 /* RevenueCatUI-RevenueCat_RevenueCatUI in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		737111EF2DE15D2F6DADB60BE6BB4302 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				018B59A32810D9C4924317B3A3F26C24 /* background.jpg in Resources */,
+				3DFDC063E8D9B4CF647ED7A2D312C39F /* icons.xcassets in Resources */,
+				4367F2B0D836707B0A6464F87F770859 /* Localizable.strings in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		74F2F0D70DD856A51F31711F28830B1E /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		FF5FEEAAAD27218928A6EDEFA0B1A4A4 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		380959975257161685C13C1E6EDDFC1F /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		9E823B29C11B1017F6CB289B11E66FF9 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				A30AD567E84A08A69EA3E79F8CA68CF2 /* AsyncButton.swift in Sources */,
+				868C3567D442B5AE72617F057C90779A /* Bundle+Extensions.swift in Sources */,
+				BBC227210D9DCC76F8CE223C2E39B9A9 /* ColorInformation+MultiScheme.swift in Sources */,
+				3EEBA761A55B92B45B1376A9B93D6549 /* ConsistentPackageContentView.swift in Sources */,
+				C57BB681941DFE76D6798F52FB96F6D4 /* Constants.swift in Sources */,
+				C70BACBDD54514C7B85E98AF04725F19 /* DebugErrorView.swift in Sources */,
+				58CB0C5AB2A6D3B8BD77E78FD7D14F5B /* ErrorDisplay.swift in Sources */,
+				7F8F6913F886359FAFF10AA128DA6601 /* FitToAspectRatio.swift in Sources */,
+				FF24C816B3F03000D43278A0C4EC27CA /* FooterHidingModifier.swift in Sources */,
+				6969D358F70DBAA1450E7E776DAF96D1 /* FooterView.swift in Sources */,
+				116BD659AAB7440FBD20DB47CA7CC834 /* IconView.swift in Sources */,
+				182A9F33025EE9704B82C1DB3EA84800 /* ImageLoader.swift in Sources */,
+				B6E0549837C0A724F07A38D30436AEA3 /* IntroEligibilityStateView.swift in Sources */,
+				ED46A473727AA5CAD9D4D85580788867 /* IntroEligibilityViewModel.swift in Sources */,
+				14E02ED940865DACA96385D44C1F7D24 /* LoadingPaywallView.swift in Sources */,
+				07013255BD7E6ABED38C997458BA0AAC /* Localization.swift in Sources */,
+				3058048818BE7A990F0B7F8BFACCA0DD /* LocalizedAlertError.swift in Sources */,
+				96D4E23AD8700BF590A344EE49AED9A7 /* Logger.swift in Sources */,
+				4621EA2EE7C665DD06AD35759377DE95 /* MockPurchases.swift in Sources */,
+				104F13F47E810E97D6C99D76B244A268 /* Optional+Extensions.swift in Sources */,
+				D7284A74D8AA61B76958B175A840AAD3 /* Package+VariableDataProvider.swift in Sources */,
+				A2F8047CFE227730D9DB9071DAB1794C /* PackageButtonStyle.swift in Sources */,
+				3B259F23B524EA8E35BFDA1E31412FF1 /* PaywallData+Default.swift in Sources */,
+				EAA2D0030FE049B94B9CD240CE2C3E10 /* PaywallData+Validation.swift in Sources */,
+				EDFC76D560DF3ED39FA45686C83E567A /* PaywallError.swift in Sources */,
+				E3A4081EFCAB527C3BFC4D630D3BA87E /* PaywallFontProvider.swift in Sources */,
+				434C91825EAE74E9C0F25EC7E8363BA4 /* PaywallFooterViewController.swift in Sources */,
+				585D0177F0EA19D8F2ECEFB0C87FF435 /* PaywallPurchasesType.swift in Sources */,
+				9B3A84588B27929B803B7239243D4626 /* PaywallTemplate.swift in Sources */,
+				0606A8EE3BD6209C1B33D74D7B2789BA /* PaywallView.swift in Sources */,
+				E2B7EC3168B241AE139C1037EA31556C /* PaywallViewConfiguration.swift in Sources */,
+				776CFDC4A39B996A5C22F336A45A66E9 /* PaywallViewController.swift in Sources */,
+				960E364D055D70DF34B2ADF84E895CC3 /* PaywallViewMode+Extensions.swift in Sources */,
+				BC7E41841487F2CB2DBBAB3D35266B2E /* PreviewHelpers.swift in Sources */,
+				04E071224DD5C8E19130ADCB3C6C62DE /* ProcessedLocalizedConfiguration.swift in Sources */,
+				2306098E446C8A93ED5279426A2B899B /* ProgressView.swift in Sources */,
+				006EE37E0CF6554326995C0A26EC2200 /* PurchaseButton.swift in Sources */,
+				A85F3B407EF32ED277DBBDAB22ED8188 /* PurchaseHandler.swift in Sources */,
+				606CED778883CD47B006E4E90F1BC866 /* PurchaseHandler+TestData.swift in Sources */,
+				FE4D2BCE661617CF42A73ED0CB774E0F /* RemoteImage.swift in Sources */,
+				D8F230E6A9BF696FC6B0C6A430AC9009 /* RevenueCatUI-dummy.m in Sources */,
+				D5B19067E1F0461F6281A063A87457D6 /* Strings.swift in Sources */,
+				E34876956A4525BA22DDEB9BC7F0D723 /* Template1View.swift in Sources */,
+				823570F6D8FCD3E7DEB0815E0F07A6E4 /* Template2View.swift in Sources */,
+				1377312B26865BDDF4A90B82625628B6 /* Template3View.swift in Sources */,
+				683F5A57E457AE89E32760F2B2E3FAFB /* Template4View.swift in Sources */,
+				0B413672C74F4D24022AC6E4A7E81021 /* Template5View.swift in Sources */,
+				2D48D7BAC5363DF7F63E5C37BE7BAF13 /* TemplateBackgroundImageView.swift in Sources */,
+				4684B08141405A68F0BC3A67FFC4EE5E /* TemplateError.swift in Sources */,
+				A1AC2A39E9CF873FD4AAA4D4FCDF3882 /* TemplateViewConfiguration.swift in Sources */,
+				0BB874C866E0C415606AED5E816DAED9 /* TemplateViewConfiguration+Extensions.swift in Sources */,
+				1D4E5C0F1661DCB092313A2B31790A9D /* TemplateViewConfiguration+Images.swift in Sources */,
+				413AE853EDE5AD449A3F5CEC5A47A21E /* TemplateViewType.swift in Sources */,
+				02DBDC623AFCDE37C027DD9A6B2D0958 /* TestData.swift in Sources */,
+				1741D22BEB57DC4D8C2CD77F2BD3A130 /* TrialOrIntroEligibilityChecker.swift in Sources */,
+				6A17767C71AD6AB533E877BFD6822061 /* TrialOrIntroEligibilityChecker+TestData.swift in Sources */,
+				44DFC9C082DCDBF87065A198E4AD0088 /* UserInterfaceIdiom.swift in Sources */,
+				7E2CF18E4FCA5A46DC1A793949F10C89 /* Variables.swift in Sources */,
+				6690AEBD1698E589EDC2D47503684148 /* VersionDetector.swift in Sources */,
+				B55D8B07D06AAC6B9A7763ADED84F288 /* View+PresentPaywall.swift in Sources */,
+				72E14CFE12B48A650433B3A1034CF260 /* View+PresentPaywallFooter.swift in Sources */,
+				CEE3C8588A47C6CA36F587FF455033BB /* View+PurchaseRestoreCompleted.swift in Sources */,
+				01E923CA33BC99A7959FEBD1FCA1A1F8 /* ViewExtensions.swift in Sources */,
+				D5983CC6DB244A8C3F98461E61628A0E /* WatchTemplateView.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		B92290284CB4286C64187C368ED13078 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				83697BC1BC0BFAFA3BDB86D8D8990F7A /* Pods-RevenueCatUIProxy-dummy.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		CC8F5F5B73F9D8EA9EE678F2D2388FA3 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				FA888FE36CD82D3904196229996F4FCC /* AfficheClientProxy.swift in Sources */,
+				344BFFE3FF3DD29681B6FDC4B70C77D2 /* AnyDecodable.swift in Sources */,
+				681824ED0A261A9B7CE4EAC55C07218C /* AnyEncodable.swift in Sources */,
+				52FA5C4F75DB8BD88D92EA9202210E6D /* AppleReceipt.swift in Sources */,
+				5DD48D3A7455E995B0251F98B2E1C37C /* AppleReceiptBuilder.swift in Sources */,
+				AB6E10FBC820B5EDB286F76CE2106D11 /* Array+Extensions.swift in Sources */,
+				0C6AE8640A3BD0281FCC077268B3A374 /* ArraySlice_UInt8+Extensions.swift in Sources */,
+				E1FC226DCFAB9486FAE9F4E36284DC0A /* ASIdManagerProxy.swift in Sources */,
+				7695012922F54E380F6419A495102C09 /* ASN1Container.swift in Sources */,
+				E7AD789D0393482A82B0F81A4A1EC07A /* ASN1ContainerBuilder.swift in Sources */,
+				D1C649D40A3C3FFD4824F693F4D14C35 /* ASN1ObjectIdentifier.swift in Sources */,
+				663626134FC58CBBCA51C8D5EED8A65A /* ASN1ObjectIdentifierBuilder.swift in Sources */,
+				13D40C311B7930FFA9C6C8EC7DE06A12 /* Assertions.swift in Sources */,
+				633D9C408CF785E33057B811D5A305A1 /* AsyncExtensions.swift in Sources */,
+				80F2AF677EB01356FCDE19243F281DB5 /* Atomic.swift in Sources */,
+				24C647F0B118A6A18B117CB4EC1970C1 /* Attribution.swift in Sources */,
+				AED9184FCAF5F0E6F85193297575DD87 /* AttributionData.swift in Sources */,
+				AB95012CD75ED95B2933A431F34F647C /* AttributionDataMigrator.swift in Sources */,
+				60143BEE051335B71E4C0C4240D08AF3 /* AttributionFetcher.swift in Sources */,
+				F7FEEC4CC2455EBE43E2A33675C6CE04 /* AttributionKey.swift in Sources */,
+				8D547D8F179B768586470F89D3F11BF8 /* AttributionNetwork.swift in Sources */,
+				E5C227C894B0056531F6A22859CD2D28 /* AttributionPoster.swift in Sources */,
+				B6731BF374FEC97B40D373A424003905 /* AttributionStrings.swift in Sources */,
+				C47619F9C4EAEE421D5051B9996BA832 /* AttributionTypeFactory.swift in Sources */,
+				975406B672E58D7233B74CD4DE2C7BC5 /* Backend.swift in Sources */,
+				906EDF1729E8927648F1AD4C1616B36C /* BackendConfiguration.swift in Sources */,
+				C3A41CF0BFD30A00DCFE730BB204C80D /* BackendError.swift in Sources */,
+				ED02D2F07CB9DACBB1D423B554CACF3D /* BackendErrorCode.swift in Sources */,
+				71D0D280CC771B6C048981820626F0BD /* BackendErrorStrings.swift in Sources */,
+				F17EE585EC7215B65AA3C253176F1E38 /* BeginRefundRequestHelper.swift in Sources */,
+				19D6A522CBE323D568DAF2F83D27D7E0 /* Box.swift in Sources */,
+				E43F395A8F3CF5CBA0A49B860A503D6E /* CacheFetchPolicy.swift in Sources */,
+				C18DFD24F9B6EA9FCE44A541CFC395F4 /* CachingProductsManager.swift in Sources */,
+				269C44FB66B5CA753BCB07BA7ADA9C8B /* CachingTrialOrIntroPriceEligibilityChecker.swift in Sources */,
+				93B530215BE4238E2DCB6069D6ED44C6 /* CallbackCache.swift in Sources */,
+				8C71AC74BA64E5B5A97AAAFB1F6132BB /* CallbackCacheStatus.swift in Sources */,
+				47C6A1A024C75EA32F90AB90B8C6021F /* Clock.swift in Sources */,
+				7A341060AA74930FDA76018A2BAEDDDF /* Codable+Extensions.swift in Sources */,
+				C31DBA526D34B4E4AF18E978B9B20DB9 /* CodableStrings.swift in Sources */,
+				F45ACF6F5FA286B857785DB0C86376B9 /* Configuration.swift in Sources */,
+				C4ED41CAF0F296BA34512DD3B1095490 /* ConfigureStrings.swift in Sources */,
+				265CA78CFD6FD24DE9007BB1B85ED501 /* CustomerAPI.swift in Sources */,
+				0A08E87B838147DB297B48D3D4A0150D /* CustomerInfo.swift in Sources */,
+				FAD61972F6EF4E39CB13B85B70C03CEA /* CustomerInfo+ActiveDates.swift in Sources */,
+				500AEFEB5120ABC8B0B6D47AAB31E257 /* CustomerInfo+NonSubscriptions.swift in Sources */,
+				692DCF2D7D2A382F49576632146A5D4C /* CustomerInfo+OfflineEntitlements.swift in Sources */,
+				D3B056A4C39385889E87239A45ACF5DC /* CustomerInfoCallback.swift in Sources */,
+				15CACBF78DD8C67209CD6807D6B78D99 /* CustomerInfoManager.swift in Sources */,
+				9557337EEC20924FED588CF84EF535DE /* CustomerInfoResponse.swift in Sources */,
+				19008C27D96D2C7A0CD2FE6786D5C963 /* CustomerInfoResponseHandler.swift in Sources */,
+				5F9AC59D244FB3B33674769F0920EE93 /* CustomerInfoStrings.swift in Sources */,
+				C1DECD1C6C0A82DEC1D090ACF573D045 /* DangerousSettings.swift in Sources */,
+				79180D5F2F19AC3E848B5F2DBB964604 /* Data+Extensions.swift in Sources */,
+				69CC1F8DFB6E8F76C9CD5050CB21C3E1 /* Date+Extensions.swift in Sources */,
+				BE7587F529ED62A5991FDC7F4F07B52C /* DateExtensions.swift in Sources */,
+				58E519B66767D9111C2548FB8F285600 /* DateFormatter+Extensions.swift in Sources */,
+				DC653C2632618AC52D482B25178188F7 /* DateProvider.swift in Sources */,
+				9EE7E67663FF49916B65A23C30DA5304 /* DebugContentViews.swift in Sources */,
+				2AE4A1515175406EB8CBBADA75D129D5 /* DebugView.swift in Sources */,
+				72B5D5D96F902D701CC5294C5B072A2E /* DebugViewController.swift in Sources */,
+				0DEBB2D5999016932F860FAF8279E419 /* DebugViewModel.swift in Sources */,
+				205DADC9E71042BEC1DC0CE25336C688 /* DebugViewSheetPresentation.swift in Sources */,
+				8E6A24415060C355E8D7E412DB756439 /* Decoder+Extensions.swift in Sources */,
+				B06CCC598FF7FA8D5C5806EB5E96429C /* DefaultDecodable.swift in Sources */,
+				AF147C181DEE04C0EE49F5EF366FAA60 /* Deprecations.swift in Sources */,
+				770B7FBA1C3994BC3BEEB3C585B1AB43 /* DescribableError.swift in Sources */,
+				E700C167D875C4656F06AA24B8F50F2F /* DeviceCache.swift in Sources */,
+				63F6392F4F935A69D91725F62A12BCF6 /* DiagnosticsStrings.swift in Sources */,
+				D07230EC4E66D68E741DB88FC636F98C /* Dictionary+Extensions.swift in Sources */,
+				3A797C8DC735B78B1842C2CFEE429122 /* DispatchTimeInterval+Extensions.swift in Sources */,
+				D1263F58F2FB17D335ED4FFEE181CEA0 /* DNSChecker.swift in Sources */,
+				4FA4651BF832A1AFDF32F60512D4562E /* Either.swift in Sources */,
+				6ABB81A1917987E5C4F8E9CA9358B635 /* EligibilityStrings.swift in Sources */,
+				FD274D5835582AB8066B112899DE3B24 /* EmptyFile.swift in Sources */,
+				CBACB0D2FBA082BC9F38427CA9E9C20B /* EncodedAppleReceipt.swift in Sources */,
+				C519EB99C7FD1114DF43714358BCB02C /* EnsureNonEmptyCollectionDecodable.swift in Sources */,
+				C8196A45C6DEF1335789C861C4BA6E6D /* EntitlementInfo.swift in Sources */,
+				D010AB9308801FE83EC7DEA96AD0F431 /* EntitlementInfos.swift in Sources */,
+				94AF9164BCE38CBC4D2598F7543A2E31 /* Error+Extensions.swift in Sources */,
+				4DF194FF183314B10301D3EED35A28A3 /* ErrorCode.swift in Sources */,
+				AE16A900AF4454AF873F9E96CF2B1951 /* ErrorDetails.swift in Sources */,
+				8BBA67B9DAFCEF8622C74D4554F61DBC /* ErrorResponse.swift in Sources */,
+				78C6740C70B2A0A4B268FC49318BF0CE /* ErrorUtils.swift in Sources */,
+				E74240672DE451BF3BB9D8DA628FBE67 /* ETagManager.swift in Sources */,
+				7615764633FFD660170E78A519BCED76 /* ETagStrings.swift in Sources */,
+				E4F5B96F03A5749492B456B6B1CE34A8 /* FakeSigning.swift in Sources */,
+				B1AC3B0AA7DC642CFE65A04D220B54C5 /* FileHandler.swift in Sources */,
+				F55603F7D985B35A6B86B90129F5D883 /* FileReader.swift in Sources */,
+				AEA7B194E7CB20CCC65C55E3B677D7B5 /* FrameworkDisambiguation.swift in Sources */,
+				72EF1B42497BC4FF0E3266F0643B3F81 /* GetCustomerInfoOperation.swift in Sources */,
+				C19C89CC60C10106B2547B35EA498137 /* GetIntroEligibilityOperation.swift in Sources */,
+				CC1A46FC7337A2FDEF6C453B51B5C527 /* GetIntroEligibilityResponse.swift in Sources */,
+				22A6A0C05BF1E8A2FA0EBFD96FB56CCF /* GetOfferingsOperation.swift in Sources */,
+				04144875667A95B3B2F613A3B2B61B67 /* GetProductEntitlementMappingOperation.swift in Sources */,
+				66C60CBE497CF1F8FD279D8C20D51A36 /* HealthOperation.swift in Sources */,
+				759C731E338479330579BF01FD112962 /* HTTPClient.swift in Sources */,
+				566401378CE4C729B3DEAEDFB042D622 /* HTTPRequest.swift in Sources */,
+				FEE3B04C326C150FBA5A941BAFDCE326 /* HTTPRequest+Signing.swift in Sources */,
+				AC76F375998E3C41D84AF99A38163961 /* HTTPRequestBody.swift in Sources */,
+				E4822B1F27235D8A7D75EC1C6AA90916 /* HTTPRequestBody+Signing.swift in Sources */,
+				5C491C76832E864DE5F50E87F667C7FE /* HTTPRequestPath.swift in Sources */,
+				21C107DEA22C3B6CD3DF357633ADBBC4 /* HTTPResponse.swift in Sources */,
+				F00C8FDAB14A43A49804B124B0CC9BDE /* HTTPResponseBody.swift in Sources */,
+				798CE2918FA9BDEFCAD4E62804A58BEE /* HTTPStatusCode.swift in Sources */,
+				63AE7F9A21CFB3FBFA2E363D9446A05D /* IdentityAPI.swift in Sources */,
+				D032CE1D0E85260C922CC81909980485 /* IdentityManager.swift in Sources */,
+				C4401AFE9E4153EC5126EE527F2C3704 /* IdentityStrings.swift in Sources */,
+				BA3BE53D34E1BDFB1433FDC91F2CB37C /* IgnoreHashable.swift in Sources */,
+				65EB3BC7B69004F127C81AC90211F392 /* InAppPurchase.swift in Sources */,
+				2A9AB90992D6BB3D2D467ADC14162AEE /* InAppPurchaseBuilder.swift in Sources */,
+				19863FC61B0919DCE1C6D9999A617FAE /* InMemoryCachedObject.swift in Sources */,
+				B05A51AAB643C2B77DA117C9ED226FF0 /* Integer+Extensions.swift in Sources */,
+				57BAD5966B4C05D3628364CA5B5F2DCF /* InternalAPI.swift in Sources */,
+				209926FDFF32EEFA5F9BDF53D2E66C5E /* IntroEligibility.swift in Sources */,
+				F09CC0D2BD9F3695101190AEFE7F6EAF /* IntroEligibilityCalculator.swift in Sources */,
+				BACDAF7CBB48CF2B08730163D01D2928 /* ISOPeriodFormatter.swift in Sources */,
+				053D6E85E904884D0DA65143D14CDB18 /* Locale+Extensions.swift in Sources */,
+				7D05D94732A29F90E71F4784E9F2196D /* LocalReceiptFetcher.swift in Sources */,
+				5637A13A81CBB3610CFD55DD041B06BD /* Lock.swift in Sources */,
+				22DDC88357A9DF2EBFF82655BAF0E881 /* Logger.swift in Sources */,
+				C81B61E806BE647EE927CA8E7165DCF8 /* LoggerType.swift in Sources */,
+				76BAB046F6EC9184EF17C6A49FD7D9FD /* LogInCallback.swift in Sources */,
+				7EB0FC2BB878FAEA733EFBE6EAC5AE6B /* LogInOperation.swift in Sources */,
+				5A001B5EC5EEA78DFAB1B4D843F298A6 /* LogIntent.swift in Sources */,
+				32CB4856686E2E838F48D10843ABDFAA /* MacDevice.swift in Sources */,
+				BBEEAB972B345897894C4627F05455B2 /* ManageSubscriptionsHelper.swift in Sources */,
+				5D1947DCB168D86F60973656DB5846A0 /* ManageSubscriptionsStrings.swift in Sources */,
+				744F0EFB24B4A355F7EE890A22DD5030 /* MapAppStoreDetector.swift in Sources */,
+				FE545196EE3B9EFBD5B4447E237A3A9C /* NetworkError.swift in Sources */,
+				44DE668C93D581EA4C06879D2C9227A5 /* NetworkOperation.swift in Sources */,
+				C6C6758EC512B4B0FC8B0B4E598F8918 /* NetworkStrings.swift in Sources */,
+				16B65D18F9B2406E356FA277B18F4DAF /* NonEmptyStringDecodable.swift in Sources */,
+				3468D0C0FB59AA9E10D85093D1291188 /* NonSubscriptionTransaction.swift in Sources */,
+				EDD75759E0328CAB0E4E36E1B3CC6354 /* Obsoletions.swift in Sources */,
+				A2FD2A12CBD2974FA69727F9F3A5697F /* Offering.swift in Sources */,
+				A82734DD680B295E12144D5FEB24F4EF /* Offerings.swift in Sources */,
+				FE4BD2F82A436D4BAA7D09BFA461858A /* OfferingsAPI.swift in Sources */,
+				7F8E44A49BA404A6107E77B935F32AB8 /* OfferingsCallback.swift in Sources */,
+				E37064489140E47DAAA0ECE594C09D09 /* OfferingsFactory.swift in Sources */,
+				8379CB389751154716719DE9DDE0BE3D /* OfferingsManager.swift in Sources */,
+				A28BC44E5638409C03CAD70B04A39611 /* OfferingsResponse.swift in Sources */,
+				EB0EC88C43067A29BB7825A1D5CC1C91 /* OfferingStrings.swift in Sources */,
+				A0FC8B90DF9C9E2624B0FA1C0C8EB873 /* OfflineCustomerInfoCreator.swift in Sources */,
+				24C4CF50B0EE9F62C2EF129434E54D50 /* OfflineEntitlementsAPI.swift in Sources */,
+				A381BE3EEA3C20A5ACDE89B74ECA44CF /* OfflineEntitlementsManager.swift in Sources */,
+				843EA1027EBB93E5AB07166D21C2479D /* OfflineEntitlementsStrings.swift in Sources */,
+				D52BC7E08D1D4703E26CA134974B42CE /* OperationDispatcher.swift in Sources */,
+				420E8E1CF31343BD2955C5F5372DBA74 /* OperationQueue+Extensions.swift in Sources */,
+				4C35BF92CAC799F7179383E37EAB1B20 /* Operators+Extensions.swift in Sources */,
+				D1101E129A2B142B140986C499ABD2C6 /* Optional+Extensions.swift in Sources */,
+				2693A3581F06FC206C0639FEB081E45C /* Package.swift in Sources */,
+				9F48C29AAAFC9E12840543EA9CF8D3DA /* PackageType.swift in Sources */,
+				C5E4DA3234DCA6436F8693C365E49790 /* PaymentQueueWrapper.swift in Sources */,
+				7012B7794DD20785FF28FEE1727CF443 /* PaywallCacheWarming.swift in Sources */,
+				C9068AFD0FCD8C16B32C5A7729937E9B /* PaywallColor.swift in Sources */,
+				7ED6B3DB4C15C3B9D270722AAEC69095 /* PaywallData.swift in Sources */,
+				B917C6418C8414D5AA2BBCF4F770D740 /* PaywallData+Localization.swift in Sources */,
+				5792629765090E66BD8AE8EEA974DC43 /* PaywallEvent.swift in Sources */,
+				00E572A6D617F3989DE3D3B963322D42 /* PaywallEventSerializer.swift in Sources */,
+				3206A0B530C8962F096DDFD1628FD504 /* PaywallEventsManager.swift in Sources */,
+				AF680C6DAC773A6EF23D652160C0B740 /* PaywallEventsRequest.swift in Sources */,
+				58419EB2A7BE69BB90E718F7AAF7DED3 /* PaywallEventStore.swift in Sources */,
+				E29885191F703C4860D3AEC0FC3A65B8 /* PaywallExtensions.swift in Sources */,
+				683FB8C4C8AA3F20BCFEB550B466BB17 /* PaywallHTTPRequestPath.swift in Sources */,
+				296DA5302EB9AD678CD4C81C827891E6 /* PaywallsStrings.swift in Sources */,
+				42728C5AEF0D78F4E79E7B6446814F0D /* PaywallStoredEvent.swift in Sources */,
+				112F3645B291AC1833148B90AE43CC07 /* PaywallViewMode.swift in Sources */,
+				49C15EACBCBE3E391D2225D18E573712 /* PeriodType+Extensions.swift in Sources */,
+				84A2D71B4FAED24AFB16358E4AA0BD7E /* PlatformInfo.swift in Sources */,
+				0EE73F9B77896B677BB68602B9219A35 /* PostAdServicesTokenOperation.swift in Sources */,
+				A3F0CC54C5A279B65D85FEFF65A86AEB /* PostAttributionDataOperation.swift in Sources */,
+				C97471DEF21B3B67D011C28C8DB1A421 /* PostOfferForSigningOperation.swift in Sources */,
+				E3C02CE07488C611F374FEE8C4D6A4C0 /* PostOfferResponse.swift in Sources */,
+				E75ADF24236C11BA9C4E45F1996BCFF2 /* PostPaywallEventsOperation.swift in Sources */,
+				ED55B7BDFAF9C2B33EA2F2717C3697E7 /* PostReceiptDataOperation.swift in Sources */,
+				64CA57BD7FDA534F45B3C006394AEF59 /* PostSubscriberAttributesOperation.swift in Sources */,
+				A3559021C6D19365E6EE932362575834 /* PriceFormatterProvider.swift in Sources */,
+				3BFE12BAD1BBF015E454C58A671CD150 /* ProcessInfo+Extensions.swift in Sources */,
+				518E8DA59A238563764C753133606A4E /* ProductEntitlementMapping.swift in Sources */,
+				118FE39619AC26C5E463E0929931074F /* ProductEntitlementMappingCallback.swift in Sources */,
+				4A5C6194F50594F285070D22A159A085 /* ProductEntitlementMappingFetcher.swift in Sources */,
+				5D7E5164BF6AD6F21154981825C58752 /* ProductEntitlementMappingResponse.swift in Sources */,
+				6BF14FFD1F282148DBAEA98E2D44249E /* ProductRequestData.swift in Sources */,
+				9E28C7230552FFD7736FF4683331B5A9 /* ProductRequestData+Initialization.swift in Sources */,
+				1F28D73B409819940831595BC4A3AB10 /* ProductsFetcherSK1.swift in Sources */,
+				55C7E4386448503A64D078A40C374130 /* ProductsFetcherSK2.swift in Sources */,
+				706B6D6EC39174B5FE3F5706FDF3107E /* ProductsManager.swift in Sources */,
+				32F054AE47164436F18B78A42CC7BB62 /* ProductsRequestFactory.swift in Sources */,
+				A4DEDD07C40C8384BE53BCD3653727B0 /* ProductType.swift in Sources */,
+				2E8CC659ED3BAF17BE0FF36880D58EA8 /* PromotionalOffer.swift in Sources */,
+				3AB8D3ECC8DB66D8BFD3C04426520624 /* PurchasedProductsFetcher.swift in Sources */,
+				1EC21BDA4349713704A92470F9169AC5 /* PurchasedSK2Product.swift in Sources */,
+				79C050535DB11F3C3AB016FEFF123ADE /* PurchaseOwnershipType.swift in Sources */,
+				66F74DA753E22121AFD9970143F64621 /* PurchaseOwnershipType+Extensions.swift in Sources */,
+				5A18E8698E9269256B6B39E6B05EE39E /* Purchases.swift in Sources */,
+				0C415C709D84CE7F07CA4AFFE137CA26 /* Purchases+async.swift in Sources */,
+				8231B1E460FA9E9CB7FD6E7F085B76B8 /* Purchases+nonasync.swift in Sources */,
+				D0C8F9BC51C80EFEDC59BF7C745000BE /* PurchasesDelegate.swift in Sources */,
+				55ADD8B6EEE9E7C99DBA21D31C0DC75A /* PurchasesDiagnostics.swift in Sources */,
+				1B0495ED6566F0D461759E3490AA9603 /* PurchasesError.swift in Sources */,
+				84AD057E9F08914BA6774CCE1029715A /* PurchasesOrchestrator.swift in Sources */,
+				A3476386630864499AFC51DF4690ED5B /* PurchasesReceiptParser.swift in Sources */,
+				ABA5147D0095962DB0E655B418648386 /* PurchaseStrings.swift in Sources */,
+				25B432F498945E24E0601147757910B4 /* PurchasesType.swift in Sources */,
+				98FC0FCE8B007215A3B07B98926B6465 /* RateLimiter.swift in Sources */,
+				EDDE58CBEC381F536694BDF36F11AB4A /* RawDataContainer.swift in Sources */,
+				3037B3D95151E50C7B3621F22A05C58D /* ReceiptFetcher.swift in Sources */,
+				F9C2803C3DABA366642DAC9CDC01CCDA /* ReceiptParserLogger.swift in Sources */,
+				745C430B8C7CE236DFDD47AC83625D53 /* ReceiptParsingError.swift in Sources */,
+				6D183093E65493328CFB160CE6327D6E /* ReceiptRefreshPolicy.swift in Sources */,
+				294601A026AD1BA464F60A9619F3F273 /* ReceiptStrings.swift in Sources */,
+				4A768F3A88648AE6B13D79C2F64903ED /* RedirectLoggerTaskDelegate.swift in Sources */,
+				CEB1CC996909F329817740F4E293F46C /* ReservedSubscriberAttributes.swift in Sources */,
+				80FD25A5427DB626FDB73E1015F5E73B /* Result+Extensions.swift in Sources */,
+				53FE1A8238B0A54247D5197495188037 /* RevenueCat-dummy.m in Sources */,
+				09CFAF601B451B7CB522FE63004D0916 /* SandboxEnvironmentDetector.swift in Sources */,
+				80499DEA76BB669B0E9B248B9500E3F9 /* Set+Extensions.swift in Sources */,
+				E88F470BEB2E850D2FA669A75F9B6916 /* Signing.swift in Sources */,
+				5572692C2A0E324FE0020CCA2E5416B8 /* Signing+ResponseVerification.swift in Sources */,
+				CC28AE340ED621984C4D629E3B681216 /* SigningStrings.swift in Sources */,
+				3B1ACDB4E76CAAF8881CC510C8898210 /* SK1Storefront.swift in Sources */,
+				B5922E8782EB26AA79C30F0C227C308A /* SK1StoreProduct.swift in Sources */,
+				42D26A54A291FC8B274F2F2670D33C2D /* SK1StoreProductDiscount.swift in Sources */,
+				DCA9A5DAD72687BD449A882C6F421B46 /* SK1StoreTransaction.swift in Sources */,
+				779B1585AA6BAAEDF50AD841C045FF5B /* SK2AppTransaction.swift in Sources */,
+				3C07B9CFC365A65446B9C6FD0D22CC9F /* SK2BeginRefundRequestHelper.swift in Sources */,
+				3AFB81D91D1E5653792F84A9A2633C4D /* SK2Storefront.swift in Sources */,
+				31D028CDC483C3C36DA148358F579C62 /* SK2StoreProduct.swift in Sources */,
+				7D1AB04D1AC1AF9979C4920C7C7C6426 /* SK2StoreProductDiscount.swift in Sources */,
+				BCF7D29E788E4F96655172DF8B021B7D /* SK2StoreTransaction.swift in Sources */,
+				689CB0CFB2B95318525371132D3E5B63 /* SKError+Extensions.swift in Sources */,
+				1C1DD057CD0EA1FB136207A517225B0B /* Store+Extensions.swift in Sources */,
+				7493BC98044DCF9E94EF8BB32F7E46CE /* StoreEnvironment.swift in Sources */,
+				F49301EF97E33765A6722A1B9E6280CC /* Storefront.swift in Sources */,
+				F7F501748E66F81D91D54E43FC6E6D44 /* StorefrontProvider.swift in Sources */,
+				75630DA32FC7A42190FA7960423DC20D /* StoreKit1Wrapper.swift in Sources */,
+				DA77F14FC0218ED9DA9C019AEFC5E621 /* StoreKit2Receipt.swift in Sources */,
+				1032461A61B2DAFB7C2208550347693C /* StoreKit2Setting.swift in Sources */,
+				F76D65BD86DF113105C93E5B578FE896 /* StoreKit2StorefrontListener.swift in Sources */,
+				944646D1BA8A645D9FDCFF3E9DA2858C /* StoreKit2TransactionFetcher.swift in Sources */,
+				4DF95AE313D4F1A60B5239E4EC9C19F2 /* StoreKit2TransactionListener.swift in Sources */,
+				6E17AA1CA5330EBB598B56C9B75CFBCF /* StoreKitError+Extensions.swift in Sources */,
+				13A6B1C3230B15B2FA89F29693F037DC /* StoreKitRequestFetcher.swift in Sources */,
+				A8A0DAAB2C68B1BC240F62B8FC5AF8E7 /* StoreKitStrings.swift in Sources */,
+				5B0525EFAA8EFB32AE377531BA05D006 /* StoreKitWorkarounds.swift in Sources */,
+				F008F1F786FC812131A15EEDA1E71CDA /* StoreMessagesHelper.swift in Sources */,
+				CB2644A73AE15E0BE7F671FE8019B4F4 /* StoreMessageType.swift in Sources */,
+				DC0DFF1026D1EB2D65DD13A02D990263 /* StoreProduct.swift in Sources */,
+				EEF39DF17655E9B8366B550C7ABFC97D /* StoreProductDiscount.swift in Sources */,
+				B8C50B35F7DAF0B7FCA39FBB2A9F2641 /* StoreTransaction.swift in Sources */,
+				30DF69679BB1956D1D0C5F09C82F0910 /* String+Extensions.swift in Sources */,
+				610C7DF1EF543B3DEE37674D60B56A7B /* Strings.swift in Sources */,
+				8FD20BD52F73387E48BA13FF98025B01 /* SubscriberAttribute.swift in Sources */,
+				D23750B64D0C49CA0E8ED607507B1BC9 /* SubscriberAttributesManager.swift in Sources */,
+				F057F98A94728AA9DDBF299A76985100 /* SubscriptionPeriod.swift in Sources */,
+				F0D42DBC32B9F86DEB9A7520D58536D7 /* SwiftVersionCheck.swift in Sources */,
+				8D105072C0EF6F8B0696D2C1721AB8AD /* SynchronizedUserDefaults.swift in Sources */,
+				12DED8673096618D59E9DC856D3DFAA9 /* SystemInfo.swift in Sources */,
+				DA82B750C01991D8EB60F589F498AE0E /* TestStoreProduct.swift in Sources */,
+				22A79868B1DF8EE86783A4397D4D52A1 /* TestStoreProductDiscount.swift in Sources */,
+				D98D8CDF18BDD0FAA3E4D8E97889D03E /* TimingUtil.swift in Sources */,
+				C10CE71AA94DE6C7E3049248C69B1C42 /* TrackingManagerProxy.swift in Sources */,
+				FDAED906C6B93A119EDA8BE6906BFC53 /* TransactionPoster.swift in Sources */,
+				EE609DFA7147F8934D9A73337658C97C /* TransactionsFactory.swift in Sources */,
+				BC30DA2FD53B912E4DE73B45E199C58F /* TransactionsManager.swift in Sources */,
+				755D65A6BEAFDB508C65C93BB96FB69C /* TrialOrIntroPriceEligibilityChecker.swift in Sources */,
+				2FD65085A50E9B42808346E38A02D6C5 /* UIApplication+RCExtensions.swift in Sources */,
+				B2AB2F4414EA5BBE70DB8496EAED9E89 /* UInt8+Extensions.swift in Sources */,
+				65606197C80DB4E107B9E2C6D597196F /* UserDefaults+Extensions.swift in Sources */,
+				36E81F2B880F2B6890C350ECA1B27180 /* VerificationResult.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		1AC8E30E76E404D364F7C9205AA295A7 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "RevenueCatUI-RevenueCat_RevenueCatUI";
+			target = CF57851EC915911B4B6C714AC16BCFFF /* RevenueCatUI-RevenueCat_RevenueCatUI */;
+			targetProxy = 071D781B3E06A82768BCF2D6D5EBC819 /* PBXContainerItemProxy */;
+		};
+		74FF2FEC0935DDA1CA2BD2536B104BE1 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = RevenueCatUI;
+			target = A57E526C97CEB07B0DAB27D9FC709692 /* RevenueCatUI */;
+			targetProxy = DB64E50BE9000E954994A667784A19F1 /* PBXContainerItemProxy */;
+		};
+		8693762801FD48452DBDE3C59653719E /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = RevenueCat;
+			target = A9FD6F34305C03A1CC3A10B207522C48 /* RevenueCat */;
+			targetProxy = D31E11CF1BE010DF9AF87CAF62652A68 /* PBXContainerItemProxy */;
+		};
+		A3713CE348B2218CB7EB98699112F7E2 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = RevenueCat;
+			target = A9FD6F34305C03A1CC3A10B207522C48 /* RevenueCat */;
+			targetProxy = C84FBE1890DFCD64ABBE7DA943115731 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin PBXVariantGroup section */
+		51B9931DD3FB99019456617147804449 /* Localizable.strings */ = {
+			isa = PBXVariantGroup;
+			children = (
+				543820EA7B80A86AD898134AB2470C15 /* Localizable.strings */,
+				876BDFA86D36230FD2F8D80E5B92FF08 /* Localizable.strings */,
+				440FFCAC3E64221C41EB1DBD4E6FE40B /* Localizable.strings */,
+				38F35B773B19A40746F29FFAEB665FCA /* Localizable.strings */,
+				93CBCB44837C8E7B15AA6A728953E280 /* Localizable.strings */,
+				91244FDBE84FA037454459DC29E1858E /* Localizable.strings */,
+				99B44BFFC4A2AE6869703B50E5AF1635 /* Localizable.strings */,
+				F5517B4B885C7E387071BB7B318046AB /* Localizable.strings */,
+				20CD4570AC2ADC5319078D71EA671872 /* Localizable.strings */,
+				F63E219033C4B04B2233CB269AF79429 /* Localizable.strings */,
+				CD4E745D50E7D6F25C396B11F6ED87E3 /* Localizable.strings */,
+				F94EA08A727DBE34A0EF45BB71A2C2E7 /* Localizable.strings */,
+				F169557230E3E27C5CD7BDB53091447A /* Localizable.strings */,
+				FDDC0E25268564B494DD9A75733F3725 /* Localizable.strings */,
+				9FD8F6B5B973819E7FB007789C700295 /* Localizable.strings */,
+				9068A239BDF55599D3B57F207FB961FF /* Localizable.strings */,
+				F9957F1A607198552234434CDC033E9F /* Localizable.strings */,
+				B5F557A6C192C2643D827890252BAA2A /* Localizable.strings */,
+				62C9C421792A5E274CBF3F9836C6C83C /* Localizable.strings */,
+				57B6CCD71E676992D5ECB28F332BD186 /* Localizable.strings */,
+				4A33F17DC912774CC470B3C97C4F20D7 /* Localizable.strings */,
+				1DA580A1B0CBCF823287724ADB279BCF /* Localizable.strings */,
+				B7C8DAAA8FB9091CEF6FC41E30160447 /* Localizable.strings */,
+				50897242FE3F0350B560DCCFB297160E /* Localizable.strings */,
+				75555DCAAE7414FCBE960E04DCBF4648 /* Localizable.strings */,
+				A68DA5DA2F5E58F0D605D2F38DD613BA /* Localizable.strings */,
+				2A76F609D62210D2D831C8EA3D519207 /* Localizable.strings */,
+				F9E365105A769FC052A58E244D969BE4 /* Localizable.strings */,
+				949DF1470B57EA96817DB8874B33D485 /* Localizable.strings */,
+				0B3E9FF33208A4C0837A100BCEBF6A8C /* Localizable.strings */,
+				CAC18679C0CA1E2F5E54AED127B14105 /* Localizable.strings */,
+				AA1A361FA3292AD4EA4440D7617DD0CE /* Localizable.strings */,
+				14E41114011B836BCA97F57D33AB71C0 /* Localizable.strings */,
+				815A1120079A6F4715100801E714382F /* Localizable.strings */,
+				4E2C1AF69886A1A3A2F3591D6882C795 /* Localizable.strings */,
+				DCC02CA3FC3C4EB4597206BE1D53C9DE /* Localizable.strings */,
+				65DEE76C6E51125654D7BE7EA5B0ED63 /* Localizable.strings */,
+				F1952DAE6C6B1C7F1AF7763D2178E4D4 /* Localizable.strings */,
+				FC60E361A6C5031053E5812E1ABBE2F4 /* Localizable.strings */,
+				14B910F48D4FA0696034A567169B3A67 /* Localizable.strings */,
+				ACAE490B9918D5AC1F9AA96433816789 /* Localizable.strings */,
+			);
+			name = Localizable.strings;
+			path = RevenueCatUI/Resources;
+			sourceTree = "<group>";
+		};
+/* End PBXVariantGroup section */
+
+/* Begin XCBuildConfiguration section */
+		16BABB1AB705D6D0F27B2E12991033A5 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 4039D362E6B5E36F2FA9A4571C5451F3 /* RevenueCatUI.release.xcconfig */;
+			buildSettings = {
+				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
+				CLANG_ENABLE_OBJC_WEAK = NO;
+				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GCC_PREFIX_HEADER = "Target Support Files/RevenueCatUI/RevenueCatUI-prefix.pch";
+				INFOPLIST_FILE = "Target Support Files/RevenueCatUI/RevenueCatUI-Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MODULEMAP_FILE = "Target Support Files/RevenueCatUI/RevenueCatUI.modulemap";
+				PRODUCT_MODULE_NAME = RevenueCatUI;
+				PRODUCT_NAME = RevenueCatUI;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
+				SWIFT_VERSION = 5.7;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+		5369F9444C74336EDF0D751317EB0593 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 4C287E21017EBC7041BEB0F82ECF89B0 /* Pods-RevenueCatUIProxy.debug.xcconfig */;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = NO;
+				CLANG_ENABLE_OBJC_WEAK = NO;
+				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = "Target Support Files/Pods-RevenueCatUIProxy/Pods-RevenueCatUIProxy-Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MACH_O_TYPE = staticlib;
+				MODULEMAP_FILE = "Target Support Files/Pods-RevenueCatUIProxy/Pods-RevenueCatUIProxy.modulemap";
+				OTHER_LDFLAGS = "";
+				OTHER_LIBTOOLFLAGS = "";
+				PODS_ROOT = "$(SRCROOT)";
+				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.${PRODUCT_NAME:rfc1034identifier}";
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		671835BA7837B7633E3E13DD576FD1E0 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 026CA7DFD3D5AB3571B6EBC7ADB35A2A /* RevenueCatUI.debug.xcconfig */;
+			buildSettings = {
+				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
+				CLANG_ENABLE_OBJC_WEAK = NO;
+				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GCC_PREFIX_HEADER = "Target Support Files/RevenueCatUI/RevenueCatUI-prefix.pch";
+				INFOPLIST_FILE = "Target Support Files/RevenueCatUI/RevenueCatUI-Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MODULEMAP_FILE = "Target Support Files/RevenueCatUI/RevenueCatUI.modulemap";
+				PRODUCT_MODULE_NAME = RevenueCatUI;
+				PRODUCT_NAME = RevenueCatUI;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
+				SWIFT_VERSION = 5.7;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		692FE7777F7082CB13A5AB4467A636B4 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 4039D362E6B5E36F2FA9A4571C5451F3 /* RevenueCatUI.release.xcconfig */;
+			buildSettings = {
+				CODE_SIGNING_ALLOWED = NO;
+				CONFIGURATION_BUILD_DIR = "$(BUILD_DIR)/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)/RevenueCatUI";
+				IBSC_MODULE = RevenueCatUI;
+				INFOPLIST_FILE = "Target Support Files/RevenueCatUI/ResourceBundle-RevenueCat_RevenueCatUI-RevenueCatUI-Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				PRODUCT_NAME = RevenueCat_RevenueCatUI;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SUPPORTS_MACCATALYST = NO;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				WRAPPER_EXTENSION = bundle;
+			};
+			name = Release;
+		};
+		831291041C7F53CCDFB8048D958F7E9F /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 186B06A2048E16FB31CD76A67AF29159 /* Pods-RevenueCatUIProxy.release.xcconfig */;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = NO;
+				CLANG_ENABLE_OBJC_WEAK = NO;
+				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = "Target Support Files/Pods-RevenueCatUIProxy/Pods-RevenueCatUIProxy-Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MACH_O_TYPE = staticlib;
+				MODULEMAP_FILE = "Target Support Files/Pods-RevenueCatUIProxy/Pods-RevenueCatUIProxy.modulemap";
+				OTHER_LDFLAGS = "";
+				OTHER_LIBTOOLFLAGS = "";
+				PODS_ROOT = "$(SRCROOT)";
+				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.${PRODUCT_NAME:rfc1034identifier}";
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+		90D4D09BCB6A4660E43ACBE9ECB6FE9A /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"POD_CONFIGURATION_DEBUG=1",
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				STRIP_INSTALLED_PRODUCT = NO;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+				SYMROOT = "${SRCROOT}/../build";
+			};
+			name = Debug;
+		};
+		9553C89E183877A5CB2F3C6801BEC129 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"POD_CONFIGURATION_RELEASE=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				STRIP_INSTALLED_PRODUCT = NO;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				SWIFT_VERSION = 5.0;
+				SYMROOT = "${SRCROOT}/../build";
+			};
+			name = Release;
+		};
+		A64CDF3726915697D3C884E3C96CCF72 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 6DFAD98DACDD279298644691491B9F6A /* RevenueCat.debug.xcconfig */;
+			buildSettings = {
+				CLANG_ENABLE_OBJC_WEAK = NO;
+				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GCC_PREFIX_HEADER = "Target Support Files/RevenueCat/RevenueCat-prefix.pch";
+				INFOPLIST_FILE = "Target Support Files/RevenueCat/RevenueCat-Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MODULEMAP_FILE = "Target Support Files/RevenueCat/RevenueCat.modulemap";
+				PRODUCT_MODULE_NAME = RevenueCat;
+				PRODUCT_NAME = RevenueCat;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
+				SWIFT_VERSION = 5.7;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		BAA4DEB992235469E5E09D5D4803BB2B /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 6313B707C269CB3C69585C430AACD82C /* RevenueCat.release.xcconfig */;
+			buildSettings = {
+				CLANG_ENABLE_OBJC_WEAK = NO;
+				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GCC_PREFIX_HEADER = "Target Support Files/RevenueCat/RevenueCat-prefix.pch";
+				INFOPLIST_FILE = "Target Support Files/RevenueCat/RevenueCat-Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MODULEMAP_FILE = "Target Support Files/RevenueCat/RevenueCat.modulemap";
+				PRODUCT_MODULE_NAME = RevenueCat;
+				PRODUCT_NAME = RevenueCat;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
+				SWIFT_VERSION = 5.7;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+		D0DDDA5056BF546FAD50D9D312C2615C /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 026CA7DFD3D5AB3571B6EBC7ADB35A2A /* RevenueCatUI.debug.xcconfig */;
+			buildSettings = {
+				CODE_SIGNING_ALLOWED = NO;
+				CONFIGURATION_BUILD_DIR = "$(BUILD_DIR)/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)/RevenueCatUI";
+				IBSC_MODULE = RevenueCatUI;
+				INFOPLIST_FILE = "Target Support Files/RevenueCatUI/ResourceBundle-RevenueCat_RevenueCatUI-RevenueCatUI-Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				PRODUCT_NAME = RevenueCat_RevenueCatUI;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SUPPORTS_MACCATALYST = NO;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				WRAPPER_EXTENSION = bundle;
+			};
+			name = Debug;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		3870AEDC4D08CA24396A926FDB0AFAE1 /* Build configuration list for PBXNativeTarget "RevenueCat" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				A64CDF3726915697D3C884E3C96CCF72 /* Debug */,
+				BAA4DEB992235469E5E09D5D4803BB2B /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		4821239608C13582E20E6DA73FD5F1F9 /* Build configuration list for PBXProject "Pods" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				90D4D09BCB6A4660E43ACBE9ECB6FE9A /* Debug */,
+				9553C89E183877A5CB2F3C6801BEC129 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		4898589D49D92F0B7559C01D1CF71EB5 /* Build configuration list for PBXNativeTarget "Pods-RevenueCatUIProxy" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				5369F9444C74336EDF0D751317EB0593 /* Debug */,
+				831291041C7F53CCDFB8048D958F7E9F /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		5074DF1F4F1F4196D5AE6710A4496636 /* Build configuration list for PBXNativeTarget "RevenueCatUI" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				671835BA7837B7633E3E13DD576FD1E0 /* Debug */,
+				16BABB1AB705D6D0F27B2E12991033A5 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		E44C0A07FE5E4E3AAC6ED8B2E72768BE /* Build configuration list for PBXNativeTarget "RevenueCatUI-RevenueCat_RevenueCatUI" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				D0DDDA5056BF546FAD50D9D312C2615C /* Debug */,
+				692FE7777F7082CB13A5AB4467A636B4 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = BFDFE7DC352907FC980B868725387E98 /* Project object */;
+}

--- a/Xamarin.RevenueCatUI.iOS/pod.sh
+++ b/Xamarin.RevenueCatUI.iOS/pod.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
 cd ios
 pod install
+cp project.pbxproj Pods/Pods.xcodeproj


### PR DESCRIPTION
- Handling incompatible build `RevenueCatUI.Framework` introduced with `pod install`. `pod install` will cause all installed pod to targe iOS 11 again. We force to copy correct `project.pbxproj` to Pods project
- Change some ApiDefinition in RevenueCatUI binding to be the same like in RevenueCat
- Add handling `DidFinishPurchasing` in `RevenueCatUI.iOS.Extensions`
- Update version
